### PR TITLE
chore: FE 멀티 페이지 번들링

### DIFF
--- a/src/frontend/game.js
+++ b/src/frontend/game.js
@@ -1,0 +1,4 @@
+import './style.scss';
+
+document.getElementById('root').innerText = 'This is game page!';
+console.log('This is game page!');

--- a/src/frontend/resources/game.html
+++ b/src/frontend/resources/game.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+  <title>Page Title</title>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = (webpackEnv) => {
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
     entry: {
       main: path.resolve(__dirname, './index.js'),
+      game: path.resolve(__dirname, './game.js'),
     },
     output: {
       path: path.resolve(__dirname, 'dist'),
@@ -19,7 +20,14 @@ module.exports = (webpackEnv) => {
     },
     plugins: [
       new HtmlWebpackPlugin({
+        filename: 'index.html',
         template: path.resolve(__dirname, './resources/index.html'),
+        chunks: ['main'],
+      }),
+      new HtmlWebpackPlugin({
+        filename: 'game.html',
+        template: path.resolve(__dirname, './resources/game.html'),
+        chunks: ['game'],
       }),
       isEnvProduction && new CleanWebpackPlugin(),
       isEnvProduction &&

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = (webpackEnv) => {
         chunks: ['main'],
       }),
       new HtmlWebpackPlugin({
-        filename: 'game.html',
+        filename: 'game/index.html',
         template: path.resolve(__dirname, './resources/game.html'),
         chunks: ['game'],
       }),


### PR DESCRIPTION
## 💁 설명

프론트엔드 멀티 페이지를 위해 웹팩 설정했습니다.
기존 페이지는 `/index.js`를 엔트리로, 새로 생기게되는 게임 페이지로는 `/game.js`를 엔트리로 사용하게 됩니다.

### 개발서버 사용 시
`localhost:9000` 접속 시 기존 페이지로, `localhost:9000/game` 접속 시 게임 페이지로 들어가게 됩니다.

### 빌드 시
![image](https://user-images.githubusercontent.com/48747221/99942022-56493900-2db2-11eb-8a0c-4f05851df00a.png)

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 디렉토리 구조
  ![image](https://user-images.githubusercontent.com/48747221/99931216-0c068e80-2d97-11eb-99ab-048faf59c71f.png)
  최상단이 너무 정신없는것같기도 해서 변경이 필요할지도 모르겠습니다!!
