### PR TITLE
메인페이지의 HTTP Request가 대응되도록 코드 일부 수정

### DIFF
--- a/src/backend/.env.sample
+++ b/src/backend/.env.sample
@@ -1,0 +1,1 @@
+FRONTEND_ORIGIN=<프론트엔드 origin. 예: http://localhost:9000>

--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import logger from 'morgan';
+import cors from 'cors';
 
 import indexRouter from './routes/index';
 
@@ -8,6 +9,11 @@ const createApplication = () => {
 
   app.use(logger('dev'));
   app.use(express.json());
+  app.use(
+    cors({
+      origin: process.env.FRONTEND_ORIGIN,
+    }),
+  );
   app.use(express.urlencoded({ extended: false }));
 
   app.use('/', indexRouter);

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -8,6 +8,7 @@
     "build": "npx webpack --mode=production"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node dist/bin/www",
-    "dev": "npx webpack --watch",
+    "start": "npx webpack --watch",
+    "dev": "npm start",
     "build": "npx webpack --mode=production"
   },
   "dependencies": {

--- a/src/backend/routes/index.js
+++ b/src/backend/routes/index.js
@@ -10,11 +10,11 @@ router.get('/rooms/:roomID', (req, res) => {
   const { roomID } = req.params;
   const game = Games.get(roomID);
   if (game && !game.IsPlaying()) {
-    res.status(200).end();
+    res.status(200).json({});
     return;
   }
 
-  res.status(403).end();
+  res.status(403).json({});
 });
 
 // 새로운 게임을 만드는 로직

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -2,12 +2,13 @@
  * Module dependencies.
  */
 
-import socketIO from '../sockets';
 import dotenv from 'dotenv';
+import debugModule from 'debug';
+import http from 'http';
+import socketIO from './sockets';
+import createApplication from './app';
 
-const debug = require('debug')('backend:server');
-const http = require('http');
-const { default: createApplication } = require('../app.js');
+const debug = debugModule('backend:server');
 
 // dotenv
 dotenv.config();
@@ -66,6 +67,7 @@ const onListening = (server) => {
   const addr = server.address();
   const bind = typeof addr === 'string' ? `pipe ${addr}` : `port ${addr.port}`;
   debug(`Listening on ${bind}`);
+  console.log(`Back end server Listening on port ${addr.port}`);
 };
 
 /**
@@ -84,7 +86,7 @@ app.set('port', normalizedPort);
 const server = http.createServer(app);
 socketIO.attach(server, {
   cors: {
-    origin: ['http://localhost:9000', 'http://127.0.0.1:9000'],
+    origin: [process.env.FRONTEND_ORIGIN],
   },
 });
 
@@ -94,5 +96,4 @@ socketIO.attach(server, {
 
 server.listen(normalizedPort);
 server.on('error', (error) => onError(error, normalizedPort));
-server.on('listening', () => onListening(server));
-console.log(`Back end server Listening on port ${normalizedPort}`);
+server.on('listening', () => onListening(server, normalizedPort));

--- a/src/backend/webpack.config.js
+++ b/src/backend/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
       '@game': path.resolve(__dirname, 'game'),
     },
   },
-  entry: [path.resolve(__dirname, 'bin/www')],
+  entry: [path.resolve(__dirname, 'server.js')],
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'app.js',

--- a/src/frontend/main/index.js
+++ b/src/frontend/main/index.js
@@ -8,8 +8,8 @@ const redirectToGameRoom = (roomCode) => {
 const requestMakeRoom = async (e) => {
   e.preventDefault();
   const config = { method: 'POST', uri: '/rooms' };
-  const { success, roomCode } = await requestHandler(config);
-  if (success) redirectToGameRoom(roomCode);
+  const { success, roomID } = await requestHandler(config);
+  if (success) redirectToGameRoom(roomID);
 };
 
 const requestEnterRoom = async (e) => {

--- a/src/frontend/utils/requestHandler.js
+++ b/src/frontend/utils/requestHandler.js
@@ -1,13 +1,15 @@
 const getHandler = async (config) => {
   const { url } = config;
   const result = await fetch(url, { ...config });
-  return { status: result.status, success: result.ok, ...result.json() };
+  const json = await result.json();
+  return { status: result.status, success: result.ok, ...json };
 };
 
 const postHandler = async (config) => {
   const { url } = config;
   const result = await fetch(url, { ...config });
-  return { status: result.status, success: result.ok, ...result.json() };
+  const json = await result.json();
+  return { status: result.status, success: result.ok, ...json };
 };
 
 const requestHandler = (config) => {


### PR DESCRIPTION
## 💁 설명

11-26 오전 회의때 다같이 수정했던 코드 PR입니다~

하~~

## 📑 체크리스트

> 구현한 목록 체크리스트

- BE express에 cors 적용 6ad7da6
- FE requestHandler() 유틸함수 return값 문제 해결 1c61083
- 백엔드와 프론트간 맞지않던 코드들 일부 수정 9f130cc
- BE 리팩토링: `./bin/www` 파일을 `./server.js`로 변경 186cb5b
  - 린트나 vscode 자동완성이 안먹는게 열받아서 그냥 js파일로 만들었습니다. 민성님 ㅈㅅ요 ㅎㅎ
  - 확장자 붙이는김에 bin폴더에 들어있으면 일반적인 bin폴더 내부구조에 어긋나게된다 생각해서 bin폴더도 없애고 www라는 이름대신 server라는 이름을 붙였습니다. express app이랑 socket.io app을 구동하는 server니까요.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

express, socket에 사용되는 cors 모두 origin을 dotenv로 관리하도록 대응했습니다.
이 PR이 merge되면 `.env.sample` 파일을 참고해서 각자 폴더에 `.env`를 생성하고 sample대로 `FRONTEND_ORIGIN`값을 넣어주세요.
prod 시에는 prod한 ncloud 내부에서 `cat >> `같은 기능으로 직접 만들어주면 dev환경과 다른 origin을 제공할 수 있겠죠??
