### PR TITLE
[Feat/chat#45] 서버 플레이어 참여 및 채팅 관련 소켓핸들링, dotenv 템플릿 수정

### DIFF
--- a/src/backend/.env.sample
+++ b/src/backend/.env.sample
@@ -1,1 +1,2 @@
-FRONTEND_ORIGIN=<프론트엔드 origin. 예: http://localhost:9000>
+[CORS]
+FRONTEND_ORIGIN=

--- a/src/backend/game/Game.js
+++ b/src/backend/game/Game.js
@@ -29,4 +29,8 @@ export default class Game {
   IsPlaying() {
     return this.status.isGaming;
   }
+
+  addUser(socketID) {
+    this.users.set(socketID, socketID);
+  }
 }

--- a/src/backend/game/Games.js
+++ b/src/backend/game/Games.js
@@ -1,0 +1,5 @@
+import Game from '@game/Game';
+
+const Games = new Map();
+
+export default Games;

--- a/src/backend/routes/index.js
+++ b/src/backend/routes/index.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import Game from '@game/Game';
-
-const Games = new Map();
+import Games from '@game/Games';
 
 const router = express.Router();
 

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -82,7 +82,6 @@ app.set('port', normalizedPort);
 /**
  * Create HTTP server.
  */
-
 const server = http.createServer(app);
 socketIO.attach(server, {
   cors: {

--- a/src/backend/sockets/chat.js
+++ b/src/backend/sockets/chat.js
@@ -1,0 +1,9 @@
+import { findRoomID } from '@utils/socket';
+
+export const onSendChat = (socket, { message }) => {
+  const roomID = findRoomID(socket);
+  if (!roomID) return;
+
+  socket.in(roomID).emit('send chat', { message });
+  socket.emit('send chat', { message });
+};

--- a/src/backend/sockets/chat.js
+++ b/src/backend/sockets/chat.js
@@ -5,5 +5,5 @@ export const onSendChat = (socket, { message }) => {
   if (!roomID) return;
 
   socket.in(roomID).emit('send chat', { message });
-  socket.emit('send chat', { message });
+  // socket.emit('send chat', { message });
 };

--- a/src/backend/sockets/index.js
+++ b/src/backend/sockets/index.js
@@ -1,11 +1,14 @@
 import io from 'socket.io';
+import { onJoinPlayer } from './waitingRoom';
+import { onSendChat } from './chat';
 
 const socketIO = io();
 
 socketIO.on('connection', (socket) => {
   console.log('a user connected');
 
-  socket.emit('hi', '123');
+  socket.on('join player', (params) => onJoinPlayer(socket, { ...params }));
+  socket.on('send chat', (params) => onSendChat(socket, { ...params }));
 });
 
 export default socketIO;

--- a/src/backend/sockets/waitingRoom.js
+++ b/src/backend/sockets/waitingRoom.js
@@ -1,0 +1,27 @@
+import Games from '@game/Games';
+import generateRandom from '@utils/generateRandom';
+
+/*
+클라이언트가 room id를 가지고 join player를 쏘면 👍
+서버에서 해당 게임에 참가할 수 있는지 확인하고 👍
+서버에서 해당 플레이어를 해당 room에 join시킨다 (socket join method) 👍
+서버는 랜덤닉네임과 랜덤컬러를 생성해서 해당 아이디를 가지는 룸에 플레이어를 enter room 시킨다. (event) 👍
+플레이어의 정보를 그 룸에 있는 다른 플레이어에게 update player를 쏜다. 👍
+*/
+export const onJoinPlayer = (socket, { roomID }) => {
+  // 일단 테스트 위해 주석 처리
+  // if (!roomID) return;
+  const game = Games.get(roomID);
+  const nickname = generateRandom.nickname();
+  const color = generateRandom.color();
+  // if (!game || !game.isPlaying) return;
+
+  // game.addUser(socket.id);
+  socket.join(roomID);
+  socket.emit('enter room', {
+    nickname,
+    color,
+    roomID,
+    players: null,
+  });
+};

--- a/src/backend/utils/generateRandom.js
+++ b/src/backend/utils/generateRandom.js
@@ -1,0 +1,4 @@
+export default {
+  nickname: () => '코딩하는 덕싯',
+  color: () => '#222222',
+};

--- a/src/backend/utils/socket.js
+++ b/src/backend/utils/socket.js
@@ -1,0 +1,3 @@
+export const findRoomID = (socket) => {
+  return [...socket.rooms].find((id) => id !== socket.id);
+};

--- a/src/frontend/.env.sample
+++ b/src/frontend/.env.sample
@@ -1,2 +1,5 @@
 [SERVER]
-API_BASE_URL=<백엔드 서버 주소>
+API_BASE_URL=
+
+[CLIENT]
+CLIENT_URL=

--- a/src/frontend/game/game.js
+++ b/src/frontend/game/game.js
@@ -2,11 +2,7 @@ import './game.scss';
 import ioClient from 'socket.io-client';
 import waitingRoom from '../scenes/waitingRoom';
 
-const socket = ioClient('http://localhost:3000');
-
-socket.on('hi', (data) => {
-  console.log(data);
-});
+const socket = ioClient(process.env.API_BASE_URL);
 
 const urlParams = new URLSearchParams(window.location.search);
 const roomCode = urlParams.get('room');


### PR DESCRIPTION
## 💁 설명

- 플레이어가 처음 들어왔을 때 emit하는 `join player` 핸들링
- 플레이어가 채팅을 전송할 때 emit하는 `send chat` 핸들링
- dotenv 템플릿 수정
- random, findRoomID 유틸함수로 분리

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 플레이어가 `join player`를 emit하면 랜덤닉네임과 랜덤컬러를 생성하여 room에 join 시키고 `enter room`으로 보내준다
- [ ] 플레이어가 `send chat`를 emit하면 해당 룸에 있는 소켓에게 메세지를 전달한다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

1. chat 을 emit할 때 소켓 주인/ 소켓주인 외 룸 플레이어 각각 보내줌
2. socket.rooms에는 socket.id가 포함되어 있음