### PR TITLE
[Feat/chat#45] 유저 클래스 추가 및 채팅 핸들러에서 닉네임 보내주게 수정

### DIFF
--- a/src/backend/game/Game.js
+++ b/src/backend/game/Game.js
@@ -26,9 +26,7 @@ export default class Game {
   }
 
   findUserInfo(socketID) {
-    console.log(socketID);
     const user = this.users.get(socketID);
-    console.log('user', user, this.users);
     return user ? user.getUserProfile() : false;
   }
 

--- a/src/backend/game/Game.js
+++ b/src/backend/game/Game.js
@@ -1,18 +1,8 @@
-const randomStrings = new Set();
-
-// 5개의 알파벳을 랜덤으로 생성. 이미 생성된 문자열일경우 다시 생성
-const generateRandomString = () => {
-  const randomString = Math.random().toString(36).substr(2, 5).toUpperCase();
-
-  if (randomStrings.has(randomString)) return generateRandomString();
-
-  randomStrings.add(randomString);
-  return randomString;
-};
+import User from './User';
 
 export default class Game {
-  constructor() {
-    this.roomID = generateRandomString();
+  constructor(roomID) {
+    this.roomID = roomID;
     this.users = new Map();
     this.status = {
       isPlaying: false,
@@ -26,11 +16,23 @@ export default class Game {
     return this.roomID;
   }
 
-  IsPlaying() {
-    return this.status.isGaming;
+  isPlaying() {
+    return this.status.isPlaying;
   }
 
-  addUser(socketID) {
-    this.users.set(socketID, socketID);
+  addUser({ socketID, nickname, color }) {
+    const user = new User({ socketID, nickname, color });
+    this.users.set(socketID, user);
+  }
+
+  findUserInfo(socketID) {
+    console.log(socketID);
+    const user = this.users.get(socketID);
+    console.log('user', user, this.users);
+    return user ? user.getUserProfile() : false;
+  }
+
+  findUserInfoAll(socketID) {
+    return this.users.get(socketID).getUserInfo() || null;
   }
 }

--- a/src/backend/game/Games.js
+++ b/src/backend/game/Games.js
@@ -9,7 +9,6 @@ class Games {
 
   isEnterableRoom(roomID) {
     const game = this.roomGameMap.get(roomID);
-    console.log(roomID, this.roomGameMap);
     if (!game) return false;
     if (game.isPlaying()) return false;
     return true;

--- a/src/backend/game/Games.js
+++ b/src/backend/game/Games.js
@@ -1,5 +1,49 @@
+import generateRandom from '@utils/generateRandom';
 import Game from '@game/Game';
 
-const Games = new Map();
+class Games {
+  constructor() {
+    this.roomGameMap = new Map();
+    this.userRoomMap = new Map();
+  }
 
-export default Games;
+  isEnterableRoom(roomID) {
+    const game = this.roomGameMap.get(roomID);
+    console.log(roomID, this.roomGameMap);
+    if (!game) return false;
+    if (game.isPlaying()) return false;
+    return true;
+  }
+
+  createGame() {
+    const game = new Game();
+    const roomID = generateRandom.code();
+    this.roomGameMap.set(roomID, game);
+    return roomID;
+  }
+
+  enterUser({ socketID, roomID }) {
+    const nickname = generateRandom.nickname();
+    const color = generateRandom.color();
+    this.userRoomMap.set(socketID, roomID);
+    this.roomGameMap.get(roomID).addUser({ socketID, roomID, nickname, color });
+  }
+
+  findRoomID(socketID) {
+    return this.userRoomMap.get(socketID) || null;
+  }
+
+  findGameBySocketID(socketID) {
+    const roomID = this.userRoomMap.get(socketID);
+    return this.roomGameMap.get(roomID) || false;
+  }
+
+  findUserInfo(socketID) {
+    const roomID = this.userRoomMap.get(socketID);
+    if (!roomID) return false;
+    const game = this.roomGameMap.get(roomID);
+    return game.findUserInfo(socketID);
+  }
+}
+
+export default new Games();

--- a/src/backend/game/User.js
+++ b/src/backend/game/User.js
@@ -1,0 +1,61 @@
+class User {
+  constructor({ socketID, nickname, color }) {
+    this.socketID = socketID;
+    this.nickname = nickname;
+    this.color = color;
+    this.turnID = 0;
+    this.submittedCard = null;
+    this.votedCard = null;
+    this.isTeller = null;
+    this.cards = [];
+    this.score = 0;
+  }
+
+  submitCard(cardID) {
+    this.submittedCard = cardID;
+  }
+
+  voteCard(cardID) {
+    this.votedCard = cardID;
+  }
+
+  addCard(cardID) {
+    this.cards = [...this.cards, cardID];
+  }
+
+  getUserInfo() {
+    const {
+      socketID,
+      nickname,
+      color,
+      turnID,
+      submittedCard,
+      votedCard,
+      isTeller,
+      cards,
+      score,
+    } = this;
+
+    return {
+      socketID,
+      nickname,
+      color,
+      turnID,
+      submittedCard,
+      votedCard,
+      isTeller,
+      cards,
+      score,
+    };
+  }
+
+  getUserProfile() {
+    const { nickname, color } = this;
+    return {
+      nickname,
+      color,
+    };
+  }
+}
+
+export default User;

--- a/src/backend/routes/index.js
+++ b/src/backend/routes/index.js
@@ -1,27 +1,20 @@
 import express from 'express';
-import Game from '@game/Game';
 import Games from '@game/Games';
 
 const router = express.Router();
 
-// 해당 게임이 있는지 검사하는 로직
 router.get('/rooms/:roomID', (req, res) => {
   const { roomID } = req.params;
-  const game = Games.get(roomID);
-  if (game && !game.IsPlaying()) {
-    res.status(200).json({});
-    return;
+  if (Games.isEnterableRoom(roomID)) {
+    return res.status(200).json({});
   }
 
-  res.status(403).json({});
+  return res.status(403).json({});
 });
 
-// 새로운 게임을 만드는 로직
 router.post('/rooms', (req, res) => {
-  const game = new Game();
-  const roomID = game.getRoomID();
-  Games.set(roomID, game);
-  res.status(200).json({ roomID });
+  const roomID = Games.createGame();
+  return res.status(200).json({ roomID });
 });
 
 export default router;

--- a/src/backend/sockets/chat.js
+++ b/src/backend/sockets/chat.js
@@ -1,9 +1,9 @@
-import { findRoomID } from '@utils/socket';
+import Games from '@game/Games';
 
 export const onSendChat = (socket, { message }) => {
-  const roomID = findRoomID(socket);
+  const roomID = Games.findRoomID(socket.id);
   if (!roomID) return;
 
-  socket.in(roomID).emit('send chat', { message });
-  // socket.emit('send chat', { message });
+  const { nickname } = Games.findUserInfo(socket.id);
+  socket.in(roomID).emit('send chat', { message, nickname });
 };

--- a/src/backend/sockets/waitingRoom.js
+++ b/src/backend/sockets/waitingRoom.js
@@ -1,27 +1,14 @@
 import Games from '@game/Games';
-import generateRandom from '@utils/generateRandom';
 
-/*
-클라이언트가 room id를 가지고 join player를 쏘면 👍
-서버에서 해당 게임에 참가할 수 있는지 확인하고 👍
-서버에서 해당 플레이어를 해당 room에 join시킨다 (socket join method) 👍
-서버는 랜덤닉네임과 랜덤컬러를 생성해서 해당 아이디를 가지는 룸에 플레이어를 enter room 시킨다. (event) 👍
-플레이어의 정보를 그 룸에 있는 다른 플레이어에게 update player를 쏜다. 👍
-*/
 export const onJoinPlayer = (socket, { roomID }) => {
-  // 일단 테스트 위해 주석 처리
-  // if (!roomID) return;
-  const game = Games.get(roomID);
-  const nickname = generateRandom.nickname();
-  const color = generateRandom.color();
-  // if (!game || !game.isPlaying) return;
+  if (!roomID || !Games.isEnterableRoom(roomID)) return;
 
-  // game.addUser(socket.id);
+  Games.enterUser({ socketID: socket.id, roomID });
+  const userInfo = Games.findUserInfo(socket.id);
   socket.join(roomID);
   socket.emit('enter room', {
-    nickname,
-    color,
+    ...userInfo,
     roomID,
-    players: null,
+    players: [],
   });
 };

--- a/src/backend/utils/generateRandom.js
+++ b/src/backend/utils/generateRandom.js
@@ -1,4 +1,17 @@
+const randomStrings = new Set();
+
+const generateRandomString = () =>
+  Math.random().toString(36).substr(2, 5).toUpperCase();
+
 export default {
   nickname: () => '코딩하는 덕싯',
   color: () => '#222222',
+  code: () => {
+    let randomString = generateRandomString();
+    while (randomStrings.has(randomString)) {
+      randomString = generateRandomString();
+    }
+    randomStrings.add(randomString);
+    return randomString;
+  },
 };


### PR DESCRIPTION
## 💁 설명

- 유저 클래스 추가
- 게임 관련 클래스 메소드 추가
- 채팅 핸들러에서 닉네임도 같이 보내주게 수정

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 어떤 플레이어가 채팅을 전송하면 해당 플레이어의 닉네임과 메세지가 함께 전달된다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

메소드들을 너무 중구난방으로 적어놔서 추후 리팩토링을 할 때
Games에 있는 것들을 Game 클래스가 하게끔 구현해야 할 듯 합니다
Games는 Game 담고, Game을 찾아주는 역할까지만!

