### PR TITLE
GitHub Actions 스크립트로 master merge 시 자동 배포 스크립트 실행

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+# GitHub Actions 공식 documentation: https://docs.github.com/en/free-pro-team/actions
+# ssh에 shell script 실행하기: https://github.com/fifsky/ssh-action/blob/master/entrypoint.sh
+
+name: Deploy master branch
+
+on:
+  push:
+    branches: [main]
+# release를 이용해서 배포할수도 있을듯요~
+#   release:
+#     types:
+#       - created
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-16.04
+    env:
+      DEPLOY_SCRIPT: shell.sh
+      DEPLOY_KEY: deploy_key
+    steps:
+      - name: Make deploy script
+        run: |
+          cat << EOF > $DEPLOY_SCRIPT
+          echo "=== pull master branch ==="
+          cd ${{ secrets.SSH_WORKING_DIRECTORY }}/src
+          git checkout master
+          git fetch origin master
+          BE_DIFF=$(git diff HEAD..origin/master --name-only -- src/backend | wc -l)
+          FE_DIFF=$(git diff HEAD..origin/master --name-only -- src/frontend | wc -l)
+          git pull origin master
+
+          if [ $BE_DIFF -ne 0 ] ; then
+            echo "=== build backend ==="
+            cd backend
+            npm ci || exit 1
+            npm run build || exit 1
+            echo "=== restart backend server ==="
+            forever stopall
+            forever start ./dist/app.js
+            cd ..
+          fi
+
+          if [ $FE_DIFF -ne 0 ] ; then
+            echo "=== build frontend ==="
+            cd frontend
+            npm ci || exit 1
+            npm run build || exit 1
+            echo "=== update nginx serve files ==="
+            # rm -rf ${{ secrets.NGINX_DIRECTORY }}
+            sudo cp ./dist/* ${{ secrets.NGINX_DIRECTORY }}
+            cd ..
+          fi
+          
+          echo "=== All done🚀 ==="
+          EOF
+
+      - name: Setting ssh agent and key
+        run: |
+          echo "${{ secrets.PRIVATE_KEY }}" > $DEPLOY_KEY
+          chmod 600 $DEPLOY_KEY
+
+      - name: Run script on ssh
+        run: ssh -i $DEPLOY_KEY -o StrictHostKeyChecking=no ${{ secrets.SSH_ORIGIN }} < $DEPLOY_SCRIPT
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          rm -f $DEPLOY_SCRIPT
+          rm -f $DEPLOY_KEY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,7 @@ name: Deploy master branch
 
 on:
   push:
-    branches: [main]
-# release를 이용해서 배포할수도 있을듯요~
-#   release:
-#     types:
-#       - created
+    branches: [master]
 
 jobs:
   Deploy:


### PR DESCRIPTION
## 💁 설명

master 브랜치에 push가 발생 될 때마다
-> BE, FE 폴더에 change가 있는지 git diff로 확인
-> change가 있으면 새로 build하고 적용

## 적용 전 확인사항

### GitHub Secrets
코드의 `${{ secret.<뭔가 secret한것> }}`은 이 repo의 `Settings`->`Secrets`에 값을 등록해야됩니다.
```
SSH_WORKING_DIRECTORY=<프로젝트 폴더>
NGINX_DIRECTORY=<NGINX 폴더>
PRIVATE_KEY=<SSH 접속용 private key>
SSH_ORIGIN=<SSH username, 호스트 쌍. 예: example@192.168.0.1>
```

### SSH public key gen
샛별님이 저희들 ssh key 넣어주셨던것처럼 github에서 사용할 ssh-key 쌍을 만들어서 public key를 authorized_keys에 넣어주셔야됩니다~~~


## 논의가 필요한 부분?

#### graceful start/shutdown 문제

BE 서버를 재시작하려 할 때, 게임서버 소켓에 연결중인 사람이 있을 경우
이 사람들을 새 서버에 옮겨주거나 이 사람들의 게임이 끝날 때 까지 서버가 꺼지지 말아야한다.
현재 forever를 사용한 재시작은 이런 요구사항을 반영할 수 없음. 

당장 생각해본 해결방법: PM2 도입해 프로세스 관리하기? 서버 메모리정보를 redis로 migration하기 등등

#### release tag 활용

<https://github.com/boostcamp-2020/Project18-B-Web-Duxit/releases>
현재 GitHub에서 tag를 이용해 release를 하고있습니다. 
master branch에 push하는게 아닌 이 release tag가 생성되는거를 github action의 발생 조건으로 사용하는 것도 가능할 것 같은데
저 혼자 단독적으로 이걸로 바꾸자 얘기할 수는 없으니 토의가 필요할거라 생각되네요.

### 필요하다면 각각에 대해 이슈를 만들어도 좋을것같네요~~