### PR TITLE
FE SceneManager 구현, 기존 scene을 class로 대응

### DIFF
--- a/src/frontend/game/game.js
+++ b/src/frontend/game/game.js
@@ -1,8 +1,9 @@
 import './game.scss';
-import { renderWaitingRoom, setupWaitingRoomSocket } from '@scenes/waitingRoom';
 import socket from '@utils/socket';
 import { $id, $create } from '@utils/dom';
 import requestHandler from '@utils/requestHandler';
+import WaitingRoom from '@scenes/waitingRoom';
+import SceneManager from '@utils/SceneManager';
 import LeftTab from './leftTab';
 
 const scrollToBottom = (component) => {
@@ -75,21 +76,21 @@ const initialize = async () => {
     window.location.href = '/';
     return;
   }
-  socket.emit('join player', { roomID });
 
   initializeLayout();
+  SceneManager.renderNextScene(new WaitingRoom(roomID));
 
-  const { NicknameInput, AllReadyText } = renderWaitingRoom(roomID);
-  setupWaitingRoomSocket({ AllReadyText });
-
+  // initialize game event socket
   socket.on('enter room', ({ nickname, players }) => {
-    NicknameInput.setValue(nickname);
+    if (SceneManager.isCurrentScene(WaitingRoom))
+      SceneManager.currentScene.setNicknameInput(nickname);
     LeftTab.initializePlayers(players);
   });
-
   socket.on('update player', (playerInfo) => {
     LeftTab.updatePlayer(playerInfo);
   });
+
+  socket.emit('join player', { roomID });
 };
 
 initialize();

--- a/src/frontend/game/game.js
+++ b/src/frontend/game/game.js
@@ -12,6 +12,25 @@ const scrollToBottom = (component) => {
   component.scrollTo(scrollOption);
 };
 
+const getMessageFromServer = ({ nickname, message }, logObject) => {
+  const messageWrapper = $create('div');
+  const nicknameBox = $create('div');
+  const messageBox = $create('div');
+
+  messageWrapper.classList.add('chat-other-player');
+  messageWrapper.appendChild(nicknameBox);
+  messageWrapper.appendChild(messageBox);
+
+  nicknameBox.classList.add('chat-nickname');
+  nicknameBox.innerText = nickname;
+
+  messageBox.classList.add('chat-message');
+  messageBox.innerText = message;
+
+  logObject.appendChild(messageWrapper);
+  scrollToBottom(logObject);
+};
+
 const initializeLayout = () => {
   const chatMessageLog = $id('chat-message-log');
   const chatForm = $id('chat-form');
@@ -41,27 +60,9 @@ const initializeLayout = () => {
     scrollToBottom(chatMessageLog);
   });
 
-  // TODO: initialize에서 분리하기
-  const getMessageFromServer = ({ nickname, message }) => {
-    const messageWrapper = $create('div');
-    const nicknameBox = $create('div');
-    const messageBox = $create('div');
+  const logMessage = (args) => getMessageFromServer(args, chatMessageLog);
 
-    messageWrapper.classList.add('chat-other-player');
-    messageWrapper.appendChild(nicknameBox);
-    messageWrapper.appendChild(messageBox);
-
-    nicknameBox.classList.add('chat-nickname');
-    nicknameBox.innerText = nickname;
-
-    messageBox.classList.add('chat-message');
-    messageBox.innerText = message;
-
-    chatMessageLog.appendChild(messageWrapper);
-    scrollToBottom(chatMessageLog);
-  };
-
-  socket.on('send chat', getMessageFromServer);
+  socket.on('send chat', logMessage);
 };
 
 const initialize = async () => {

--- a/src/frontend/scenes/someNextScene/index.js
+++ b/src/frontend/scenes/someNextScene/index.js
@@ -1,0 +1,14 @@
+import TextObject from '@engine/TextObject';
+
+const SomeNextScene = class {
+  render({ root } = {}) {
+    const text = new TextObject();
+    text.attachToRoot();
+    text.addClass('waiting-text-all-ready');
+    text.setContent('하하');
+  }
+
+  wrapup() {}
+};
+
+export default SomeNextScene;

--- a/src/frontend/scenes/waitingRoom/index.js
+++ b/src/frontend/scenes/waitingRoom/index.js
@@ -1,2 +1,29 @@
-export { default as renderWaitingRoom } from './render';
-export { default as setupWaitingRoomSocket } from './socket';
+import renderWaitingRoom from './render';
+import setupWaitingRoomSocket from './socket';
+
+const WaitingRoom = class {
+  constructor(roomID) {
+    this.roomID = roomID;
+  }
+
+  render(root) {
+    const { removeArray, NicknameInput, AllReadyText } = renderWaitingRoom(
+      this.roomID,
+    );
+    this.removeArray = removeArray;
+    this.NicknameInput = NicknameInput;
+    setupWaitingRoomSocket({ AllReadyText });
+  }
+
+  wrapup() {
+    this.removeArray.forEach((gameObject) => {
+      gameObject.delete();
+    });
+  }
+
+  setNicknameInput(nickname) {
+    this.NicknameInput.setValue(nickname);
+  }
+};
+
+export default WaitingRoom;

--- a/src/frontend/scenes/waitingRoom/render.js
+++ b/src/frontend/scenes/waitingRoom/render.js
@@ -79,7 +79,7 @@ const renderWaitingRoom = (roomID = '') => {
   AllReadyText.setContent('잠시 뒤 게임이 시작됩니다.');
   AllReadyText.attachToRoot();
 
-  const removeArray = [Header, ActionWrapper, GameCodeWrapper];
+  const removeArray = [Header, ActionWrapper, GameCodeWrapper, AllReadyText];
 
   return {
     removeArray,

--- a/src/frontend/scenes/waitingRoom/socket.js
+++ b/src/frontend/scenes/waitingRoom/socket.js
@@ -1,4 +1,6 @@
 import socket from '@utils/socket';
+import SceneManager from '../../utils/SceneManager';
+import SomeNextScene from '../someNextScene';
 
 const setupWaitingRoomSocket = ({ AllReadyText }) => {
   const onAllReady = () => {
@@ -16,10 +18,7 @@ const setupWaitingRoomSocket = ({ AllReadyText }) => {
   };
 
   const onGameStart = () => {
-    // TODO: scene이 넘어가야됨!!!
-    // renderWhoIsTeller()
-    // SceneManager.requestNextScene('who is teller');
-    // dispatch('new scene', 'who is teller');
+    SceneManager.renderNextScene(new SomeNextScene());
   };
 
   const onGameStartAborted = () => {

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -1,0 +1,21 @@
+import { $id } from '@utils/dom';
+
+const root = $id('root');
+
+const SceneManager = {
+  constructor({ currentScene = null } = {}) {
+    this.currentScene = currentScene;
+  },
+
+  renderNextScene(scene, ...args) {
+    if (this.currentScene) this.currentScene.wrapup();
+    scene.render(root, args);
+    this.currentScene = scene;
+  },
+
+  isCurrentScene(classObject) {
+    return this.currentScene.constructor.name === classObject.name;
+  },
+};
+
+export default SceneManager;

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -3,9 +3,7 @@ import { $id } from '@utils/dom';
 const root = $id('root');
 
 const SceneManager = {
-  constructor({ currentScene = null } = {}) {
-    this.currentScene = currentScene;
-  },
+  currentScene: null,
 
   renderNextScene(scene, ...args) {
     if (this.currentScene) this.currentScene.wrapup();


### PR DESCRIPTION
## 💁 설명

Scene 전환과 현재 Scene에 대한 접근을 관리하는 SceneManager를 util폴더에 구현했습니다.

### SceneManager
#### renderNextScene(`<다음 scene instance>`)
현재 scene을 wrapup하고 다음 scene을 render합니다.

#### isCurrentScene(`<비교하고자 하는 scene class>`)
현재 scene이 해당 class가 맞는지 true/false로 반환합니다.

### Scene classes
`someNextScene/index.js` 파일 참고하셔서 render, wrapup 함수만 필수로 만들어주시면 됩니다.


## ☠ 주의사항??
- `game.js` 상단 코드 변경은 refactor입니다.
- 확인 다 하시면 예시로 사용한 `someNextScene` 폴더는 나중에 다른 scene으로 대체하거나 삭제하면 될 듯 합니다.