### PR TITLE
새로 고침시 유저 증식하는 버그 해결

### DIFF
--- a/src/backend/sockets/exitRoom.js
+++ b/src/backend/sockets/exitRoom.js
@@ -1,9 +1,13 @@
 function exitRoom() {
   const socket = this;
-  socket.game?.removeUser({ socketID: socket.id });
   if (process.env.NODE_ENV === 'development') {
     console.log(`user disconnected ${socket.id}`);
   }
+  const { roomID } = socket.game;
+  const passedData = { socketID: socket.id };
+  socket.in(roomID).emit('exit player', passedData);
+
+  socket.game?.removeUser({ socketID: socket.id });
 }
 
 export default function onWaitingRoom(socket) {

--- a/src/frontend/game/game.js
+++ b/src/frontend/game/game.js
@@ -91,7 +91,9 @@ const initialize = async () => {
   socket.on('update player', (playerInfo) => {
     LeftTab.updatePlayer(playerInfo);
   });
-
+  socket.on('exit player', (playerInfo) => {
+    LeftTab.deletePlayer(playerInfo);
+  });
   socket.emit('join player', { roomID });
   socket.on('get round data', (data) =>
     SceneManager.renderNextScene(

--- a/src/frontend/game/leftTab.js
+++ b/src/frontend/game/leftTab.js
@@ -26,12 +26,24 @@ class LeftTab {
     return duck;
   }
 
+  findPlayer(socketID) {
+    return this.players.find((player) => player.socketID === socketID);
+  }
+
   updatePlayer(playerInfo) {
-    const updatedPlayer = this.players.find(
-      (player) => player.socketID === playerInfo.socketID,
-    );
+    const updatedPlayer = this.findPlayer(playerInfo.socketID);
     if (updatedPlayer) updatedPlayer.update(playerInfo);
     else this.addPlayer(playerInfo);
+  }
+
+  deletePlayer(playerInfo) {
+    const deletedPlayer = this.findPlayer(playerInfo.socketID);
+    const playerWrapper = $id('participants-wrapper');
+    playerWrapper.removeChild(deletedPlayer.instance);
+    this.players = this.players.filter(
+      (player) => player.socketID !== playerInfo.socketID,
+    );
+    this.renderCount();
   }
 
   addPlayer(playerInfo) {


### PR DESCRIPTION
## 💁 설명

새로고침을 하거나 유저가 나갔을 경우가 반영되지 않는 현상이 있었는데 이를 해결

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 나간 유저 캐릭터 삭제
- [ ] 유저가 나가면 유저수를 다시 카운트

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 재사용이 될 것 같아 findPlayer라는 함수를 만든 후 이 함수를 통해 원하는 유저를 찾고 있습니다. 
