### PR TITLE
PlayerManager 구현. 그외 자잘한 버그들 대응?

### DIFF
--- a/src/backend/game/Game.js
+++ b/src/backend/game/Game.js
@@ -20,7 +20,7 @@ export default class Game {
   start() {
     this.status = {
       ...this.status,
-      isPlaying: GAME_STATE.TELLER,
+      state: GAME_STATE.TELLER,
       unusedCards: generateRandom.cards(CARD.DECK),
     };
     [...this.users.values()].forEach((user, index) => {
@@ -33,7 +33,7 @@ export default class Game {
     // 아직 사용되지 않은 함수
     this.status = {
       ...this.status,
-      isPlaying: GAME_STATE.WAITING,
+      state: GAME_STATE.WAITING,
     };
   }
 
@@ -119,17 +119,17 @@ export default class Game {
     const isFirstTurn = turn === 1;
     const teller = [...users.values()][turn % users.size];
     const { socketID: tellerID } = teller;
-    const emptyHand = isFirstTurn ? CARD.HAND : 1;
+    const requiredCardCount = isFirstTurn ? CARD.HAND : 1;
 
     // 카드가 부족한지 체크
-    const outOfDeck = unusedCards.length < users.size * emptyHand;
+    const outOfDeck = unusedCards.length < users.size * requiredCardCount;
     // if (outOfDeck) {
     //   // TODO: 점수나 승자같은 결과를 내면서 턴을 끝내야되요~
     //   return;
     // }
 
     users.forEach((user) => {
-      const cards = this.dealCards(user.cards, emptyHand);
+      const cards = this.dealCards(user.cards, requiredCardCount);
       const params = { tellerID, cards };
       user.initOnRound(params);
       socketIO.to(user.socketID).emit('get round data', params);

--- a/src/backend/sockets/waitingRoom.js
+++ b/src/backend/sockets/waitingRoom.js
@@ -22,9 +22,13 @@ function onJoinPlayer({ roomID }) {
     .emit('update player', { ...user.getProfile(), socketID: socket.id });
 }
 
-function onUpdatePlayer({ nickname, color }) {
+function onUpdatePlayer(params = {}) {
   const socket = this;
-  const { roomID } = socket.game;
+  const {
+    user,
+    game: { roomID },
+  } = socket;
+  const { nickname = user.nickname, color = user.color } = params;
   const passedData = { nickname, color, socketID: socket.id };
 
   socket.game.updateUserProfile(passedData);

--- a/src/backend/utils/generateRandom.js
+++ b/src/backend/utils/generateRandom.js
@@ -28,7 +28,7 @@ const randomFunctions = {
   cards: (count) =>
     Array.from({ length: process.env.CARD_COUNT }, (value, index) => index)
       .sort(sortByRandom)
-      .slice(count),
+      .slice(0, count),
   pickOneFromArray: (array) => {
     return array[Math.floor(Math.random() * array.length)];
   },

--- a/src/frontend/game/leftTab.js
+++ b/src/frontend/game/leftTab.js
@@ -2,29 +2,32 @@ import './left.scss';
 import { $id } from '@utils/dom';
 import DuckObject from '@engine/DuckObject';
 import { DUCK_TYPE } from '@utils/type';
+import PlayerManager from '@utils/PlayerManager';
+
+const createDuck = (duckInfo) => {
+  const { socketID, color, nickname } = duckInfo;
+  const duck = new DuckObject({ type: DUCK_TYPE.LEFT_TAB, socketID });
+  duck.setNickname(nickname);
+  duck.setColor(color);
+  duck.createElement();
+  return duck;
+};
 
 class LeftTab {
   constructor() {
     this.players = [];
+    PlayerManager.onInitialize.push(this.initializePlayers.bind(this));
+    PlayerManager.onUpdate.push(this.updatePlayer.bind(this));
+    PlayerManager.onDelete.push(this.deletePlayer.bind(this));
   }
 
   initializePlayers(players = []) {
     const ducks = players.reduce((prev, player) => {
-      const duck = this.createDuck(player);
+      const duck = createDuck(player);
       return [...prev, duck];
     }, []);
     this.players = ducks;
     this.render();
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  createDuck(duckInfo) {
-    const { socketID, color, nickname } = duckInfo;
-    const duck = new DuckObject({ type: DUCK_TYPE.LEFT_TAB, socketID });
-    duck.setNickname(nickname);
-    duck.setColor(color);
-    duck.createElement();
-    return duck;
   }
 
   findPlayer(socketID) {
@@ -48,7 +51,7 @@ class LeftTab {
   }
 
   addPlayer(playerInfo) {
-    const duck = this.createDuck(playerInfo);
+    const duck = createDuck(playerInfo);
     const playerWrapper = $id('participants-wrapper');
     this.players = [...this.players, duck];
     playerWrapper.appendChild(duck.instance);
@@ -63,7 +66,9 @@ class LeftTab {
   render() {
     this.renderCount();
     const playerWrapper = $id('participants-wrapper');
-    this.players.map((player) => playerWrapper.appendChild(player.instance));
+    this.players.forEach((player) => {
+      playerWrapper.appendChild(player.instance);
+    });
   }
 }
 

--- a/src/frontend/scenes/waitingRoom/events.js
+++ b/src/frontend/scenes/waitingRoom/events.js
@@ -19,7 +19,7 @@ export const changeNickname = (NicknameInput) => {
     // 이전 닉네임으로 되돌아가는 기능 추가해야 함
     return;
   }
-  socket.emit('update player', { nickname: newNickname, color: '#578' });
+  socket.emit('update player', { nickname: newNickname });
 };
 
 export const toggleReady = ({ target }) => {

--- a/src/frontend/scenes/waitingRoom/index.js
+++ b/src/frontend/scenes/waitingRoom/index.js
@@ -1,9 +1,12 @@
+import PlayerManager from '@utils/PlayerManager';
 import renderWaitingRoom from './render';
 import setupWaitingRoomSocket from './socket';
 
 const WaitingRoom = class {
   constructor(roomID) {
     this.roomID = roomID;
+
+    PlayerManager.onUpdate.push(this.setNicknameInput.bind(this));
   }
 
   render() {
@@ -21,8 +24,9 @@ const WaitingRoom = class {
     });
   }
 
-  setNicknameInput(nickname) {
-    this.NicknameInput.setValue(nickname);
+  setNicknameInput({ socketID, nickname }) {
+    if (socketID === PlayerManager.currentPlayerID)
+      this.NicknameInput.setValue(nickname);
   }
 };
 

--- a/src/frontend/utils/Player.js
+++ b/src/frontend/utils/Player.js
@@ -1,0 +1,11 @@
+const Player = class {
+  constructor({ socketID, nickname, color, score = 0, isTeller = false } = {}) {
+    this.socketID = socketID;
+    this.nickname = nickname;
+    this.color = color;
+    this.score = score;
+    this.isTeller = isTeller;
+  }
+};
+
+export default Player;

--- a/src/frontend/utils/PlayerManager.js
+++ b/src/frontend/utils/PlayerManager.js
@@ -1,0 +1,81 @@
+import Player from './Player';
+import socket from './socket';
+
+const PlayerManager = class extends Map {
+  constructor(...props) {
+    super(...props);
+    this.currentPlayerID = '';
+    this.tellerID = '';
+
+    this.onInitialize = [];
+    this.onUpdate = [];
+    this.onDelete = [];
+  }
+
+  initialize(players = []) {
+    this.currentPlayerID = socket.id;
+    this.tellerID = '';
+    super.clear();
+    players.forEach((player) => super.set(player.socketID, new Player(player)));
+    this.onInitialize.forEach((callback) => callback(this.getArray()));
+  }
+
+  setTellerID(tellerID = '') {
+    this.tellerID = tellerID;
+    this.forEach((player) => {
+      const isTeller = player.socketID === tellerID;
+      this.set({
+        ...player,
+        isTeller,
+      });
+    });
+  }
+
+  set(player = {}) {
+    const { socketID } = player;
+    if (!socketID) return this;
+
+    const old = this.get(socketID) || {};
+    const updated = { ...old, ...player };
+    super.set(socketID, new Player(updated));
+
+    this.onUpdate.forEach((callback) => callback(updated));
+    return this;
+  }
+
+  updateCurrentPlayer(player = {}) {
+    this.set({ ...player, socketID: this.currentPlayerID });
+  }
+
+  delete(socketID) {
+    const result = super.delete(socketID);
+    this.onDelete.forEach((callback) => callback({ socketID }));
+    return result;
+  }
+
+  clear() {
+    this.initialize();
+  }
+
+  getMapObject() {
+    return this.map.entries.reduce(
+      (state, [socketID, player]) => ({ ...state, [socketID]: player }),
+      {},
+    );
+  }
+
+  getArray() {
+    return [...this.values()];
+  }
+
+  getCurrentPlayer() {
+    return this.get(this.currentPlayerID);
+  }
+
+  getTeller() {
+    if (this.tellerID) return this.map.get(this.tellerID);
+    return [...this.map].find((player) => player.isTeller) || null;
+  }
+};
+
+export default new PlayerManager();


### PR DESCRIPTION
## 💁 설명

### 버그 대응

https://github.com/boostcamp-2020/Project18-B-Web-Duxit/pull/111/files/dabfc4c8880a15b9055499de6218b7e75913020f

### PlayerManager 13070f7

- 기본적으로 js Map을 extend해 사용
- Player 모델도 생성 (socketID, nickname, color, score, isTeller만 가지고 있는 아주 간단한 구조체)
- Player Map을 기본으로 현재 tellerID, 현재 플레이중인 currentPlayer의 접근을 용이하게함
- onInitialize, onUpdate, onDelete 시 등록된 callback을 실행
- subscribe만 있고 unsubscribe는 없는 상태

기본적으로 쓸려나 안쓸려나 싶은 메소드들을 이것저것 넣어둔상태라 실제로 실용성이 없을 메소드도 있을것같아요. 피드백을 기다립니다💪

### PlayerManager 사용 방법

- a279e86 changes 참고해주세요.
  기본적으로 `PlayerManager.onUpdate.push(<함수>.bind(this))` 를 많이 사용하게 될 것 같습니다.

- 이번 change로 roundStart scene을 참조하지 않게 되었습니다. (앞으로 사용할 일이 없을지도? 아니면 있을지도??)

## 고민거리?

- 내가 현재 가진 card를 관리하는 manager는 없는상태인데. 이거 그냥 PlayerManager에 포함시켜버릴까요????
- currentPlayer 받아올수있는것처럼 teller도 받아오는게 좋겠죠?????