### PR TITLE
변경된 Socket 명세서 반영 + 카드 한 장씩 떨어지는 효과 연결

### DIFF
--- a/src/backend/sockets/guesserSelectCard.js
+++ b/src/backend/sockets/guesserSelectCard.js
@@ -8,8 +8,10 @@ function onSendGuesserDecision({ cardID }) {
   if (game.status.state !== GAME_STATE.GUESSER) return;
 
   user.submitCard(cardID);
-  socket.emit('guesser select card', { playerID: socket.id });
-  socket.in(game.roomID).emit('guesser select card', { playerID: socket.id });
+  socket.emit('guesser select card', { cardID });
+  socket
+    .in(game.roomID)
+    .emit('other guesser decision', { playerID: socket.id });
 }
 
 export default function onGuesserSelectCard(socket) {

--- a/src/backend/sockets/tellerSelectCard.js
+++ b/src/backend/sockets/tellerSelectCard.js
@@ -11,7 +11,7 @@ function onSendTellerDecision({ cardID, topic }) {
   user.submitCard(cardID);
   game.updateTopic(topic);
   socket.emit('teller select card', { cardID, topic });
-  socket.in(game.roomID).emit('teller select card', { topic });
+  socket.in(game.roomID).emit('teller decision', { topic });
   game.updateState(GAME_STATE.GUESSER);
 }
 

--- a/src/frontend/scenes/guesserSelectCard/socket.js
+++ b/src/frontend/scenes/guesserSelectCard/socket.js
@@ -1,17 +1,20 @@
 import socket from '@utils/socket';
-import PlayerManager from '@utils/PlayerManager';
+import CardManager from '@utils/CardManager';
 import SceneManager from '@utils/SceneManager';
 import PlayerWaiting from '../playerWaiting';
 
 const setupGuesserSelectCard = ({ ProgressBar }) => {
-  const onGuesserSelectCard = ({ playerID }) => {
-    const { currentPlayerID } = PlayerManager;
-    if (playerID === currentPlayerID) {
-      SceneManager.renderNextScene(new PlayerWaiting({ ProgressBar }));
-    }
+  const onGuesserSelectCard = ({ cardID }) => {
+    CardManager.addSubmittedCardCount();
+    SceneManager.renderNextScene(new PlayerWaiting({ ProgressBar }));
+  };
+
+  const onOtherGuesserSelectCard = ({ playerID }) => {
+    CardManager.addSubmittedCardCount();
   };
 
   socket.on('guesser select card', onGuesserSelectCard);
+  socket.on('other guesser decision', onOtherGuesserSelectCard);
 };
 
 export default setupGuesserSelectCard;

--- a/src/frontend/scenes/guesserWaiting/socket.js
+++ b/src/frontend/scenes/guesserWaiting/socket.js
@@ -6,10 +6,11 @@ import GuesserSelectCard from '../guesserSelectCard';
 const setupGuesserWaiting = () => {
   const onTellerSelectCard = ({ topic }) => {
     CardManager.updateTopic(topic);
+    CardManager.addSubmittedCardCount();
     SceneManager.renderNextScene(new GuesserSelectCard());
   };
 
-  socket.on('teller select card', onTellerSelectCard);
+  socket.on('teller decision', onTellerSelectCard);
 };
 
 export default setupGuesserWaiting;

--- a/src/frontend/scenes/playerWaiting/index.js
+++ b/src/frontend/scenes/playerWaiting/index.js
@@ -35,7 +35,7 @@ const PlayerWaiting = class {
     myDuck.setDepth(3);
     this.duckMoveEvent = (e) => moveMyDuck(e, myDuck);
     $id('root').addEventListener('click', this.duckMoveEvent);
-    Array.from({ length: CardManager.submittedCount }, () =>
+    Array.from({ length: CardManager.beforeSubmittedCount }, () =>
       CardManager.dropNewCard(),
     );
     setupPlayerWaiting();

--- a/src/frontend/scenes/playerWaiting/index.js
+++ b/src/frontend/scenes/playerWaiting/index.js
@@ -1,5 +1,4 @@
 import './style.scss';
-import CardObject from '@engine/CardObject';
 import DuckObject from '@engine/DuckObject';
 import PlayerManager from '@utils/PlayerManager';
 import CardManager from '@utils/CardManager';
@@ -7,6 +6,7 @@ import { $id } from '@utils/dom';
 import { DUCK_TYPE } from '@type/duck';
 import renderPlayerWaiting from './render';
 import { moveMyDuck } from '../waitingRoom/events';
+import setupPlayerWaiting from './socket';
 
 const createDuck = ({
   color = '',
@@ -25,7 +25,6 @@ const createDuck = ({
 
 const PlayerWaiting = class {
   constructor() {
-    this.cards = [];
     this.ducks = new Map();
 
     PlayerManager.forEach(({ socketID, ...duckData }) => {
@@ -37,21 +36,9 @@ const PlayerWaiting = class {
     this.duckMoveEvent = (e) => moveMyDuck(e, myDuck);
     $id('root').addEventListener('click', this.duckMoveEvent);
     Array.from({ length: CardManager.submittedCount }, () =>
-      this.dropNewCard(),
+      CardManager.dropNewCard(),
     );
-  }
-
-  dropNewCard() {
-    const newCard = new CardObject({
-      origin: [50, 50],
-      position: [50, -50],
-    });
-    newCard.setWidth(150);
-    newCard.angle = Math.random() * 360 - 180;
-    newCard.roll(40 + Math.random() * 20, 65 + Math.random() * 20, 3000);
-    newCard.attachToRoot();
-
-    this.cards = [...this.cards, newCard];
+    setupPlayerWaiting();
   }
 
   render() {

--- a/src/frontend/scenes/playerWaiting/index.js
+++ b/src/frontend/scenes/playerWaiting/index.js
@@ -1,9 +1,10 @@
 import './style.scss';
 import CardObject from '@engine/CardObject';
 import DuckObject from '@engine/DuckObject';
-import { DUCK_TYPE } from '@type/duck';
 import PlayerManager from '@utils/PlayerManager';
+import CardManager from '@utils/CardManager';
 import { $id } from '@utils/dom';
+import { DUCK_TYPE } from '@type/duck';
 import renderPlayerWaiting from './render';
 import { moveMyDuck } from '../waitingRoom/events';
 
@@ -35,7 +36,9 @@ const PlayerWaiting = class {
     myDuck.setDepth(3);
     this.duckMoveEvent = (e) => moveMyDuck(e, myDuck);
     $id('root').addEventListener('click', this.duckMoveEvent);
-    this.dropNewCard();
+    Array.from({ length: CardManager.submittedCount }, () =>
+      this.dropNewCard(),
+    );
   }
 
   dropNewCard() {

--- a/src/frontend/scenes/playerWaiting/socket.js
+++ b/src/frontend/scenes/playerWaiting/socket.js
@@ -1,0 +1,12 @@
+import socket from '@utils/socket';
+import CardManager from '@utils/CardManager';
+
+const setupPlayerWaiting = () => {
+  const onOtherGuesserSelectCard = () => {
+    CardManager.dropNewCard();
+  };
+
+  socket.on('other guesser decision', onOtherGuesserSelectCard);
+};
+
+export default setupPlayerWaiting;

--- a/src/frontend/scenes/tellerSelectCard/socket.js
+++ b/src/frontend/scenes/tellerSelectCard/socket.js
@@ -5,8 +5,9 @@ import PlayerWaiting from '../playerWaiting';
 
 const setupTellerSelectSocket = () => {
   const onTellerSelectCard = ({ topic }) => {
-    SceneManager.renderNextScene(new PlayerWaiting());
     CardManager.updateTopic(topic);
+    CardManager.addSubmittedCardCount();
+    SceneManager.renderNextScene(new PlayerWaiting());
   };
 
   socket.on('teller select card', onTellerSelectCard);

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -3,6 +3,7 @@ const CardManager = class {
     this.myCards = [];
     this.selectedCard = null;
     this.topic = null;
+    this.submittedCount = 0;
   }
 
   initailizeMyCards(cards) {
@@ -23,6 +24,10 @@ const CardManager = class {
 
   updateTopic(topic) {
     this.topic = topic;
+  }
+
+  addSubmittedCardCount() {
+    this.submittedCount += 1;
   }
 };
 

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -1,8 +1,11 @@
+import CardObject from '@engine/CardObject';
+
 const CardManager = class {
   constructor() {
     this.myCards = [];
     this.selectedCard = null;
     this.topic = null;
+    this.submittedCards = [];
     this.submittedCount = 0;
   }
 
@@ -28,6 +31,23 @@ const CardManager = class {
 
   addSubmittedCardCount() {
     this.submittedCount += 1;
+  }
+
+  addSubmittedCard(cardObject) {
+    this.submittedCards = [...this.submittedCards, cardObject];
+  }
+
+  dropNewCard() {
+    const newCard = new CardObject({
+      origin: [50, 50],
+      position: [50, -50],
+    });
+    newCard.setWidth(150);
+    newCard.angle = Math.random() * 360 - 180;
+    newCard.roll(40 + Math.random() * 20, 65 + Math.random() * 20, 3000);
+    newCard.attachToRoot();
+
+    this.addSubmittedCard(newCard);
   }
 };
 

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -6,7 +6,7 @@ const CardManager = class {
     this.selectedCard = null;
     this.topic = null;
     this.submittedCards = [];
-    this.submittedCount = 0;
+    this.beforeSubmittedCount = 0;
   }
 
   initailizeMyCards(cards) {
@@ -30,7 +30,7 @@ const CardManager = class {
   }
 
   addSubmittedCardCount() {
-    this.submittedCount += 1;
+    this.beforeSubmittedCount += 1;
   }
 
   addSubmittedCard(cardObject) {


### PR DESCRIPTION
## 💁 설명

socket 변경된 명세서를 반영해서 서버/프론트 모두 수정완료!
- 해람님이 만드신 카드 떨어지는 효과는 내가 카드를 제출하기 전까지 쌓아둔 count 만큼 반복
- 이후 playerWaiting으로 진입하게 되면 다른 플레이어가 제출할 때마다 dropNewCard를 실행
- 기존 dropNewCard 함수는 카드 매니저에게 넘겨줬고 카드 관리 또한 카드 매니저가 하게 됩니다.

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 플레이어가 카드를 선택하면 그 전에 선택한 사람의 수만큼 (텔러 포함) 카드가 떨어진다.
- [ ] 다른 플레이어가 카드를 제출하면 카드가 한장씩 떨어진다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- close #142 
- close #148 
