### PR TITLE
준비상태에 있는 오리들만 보이게 수정

### DIFF
--- a/src/backend/game/User.js
+++ b/src/backend/game/User.js
@@ -81,11 +81,12 @@ class User {
   }
 
   getProfile() {
-    const { nickname, color, score } = this;
+    const { nickname, color, score, isReady } = this;
     return {
       nickname,
       color,
       score,
+      isReady,
     };
   }
 

--- a/src/frontend/engine/DuckCursorObject.js
+++ b/src/frontend/engine/DuckCursorObject.js
@@ -31,23 +31,32 @@ class DuckCursorObject extends DuckObejct {
     this.render();
   }
 
-  makeFollowMouse() {
-    $id('root').addEventListener('mousemove', (event) => {
-      if (this.throttling) {
-        this.lastPosition = calcPosition(event);
-        return;
-      }
+  addMouseMoveEvent() {
+    $id('root').addEventListener('mousemove', (event) =>
+      this.makeFollowMouse(event),
+    );
+  }
 
-      this.throttling = true;
-      this.moveToMouse(calcPosition(event));
-      setTimeout(() => {
-        this.throttling = false;
-        if (this.lastPosition) {
-          this.moveToMouse(this.lastPosition);
-          this.lastPosition = null;
-        }
-      }, TIME.DUCK_THROTTLE);
-    });
+  removeMouseMoveEvent() {
+    $id('root').removeEventListener('mousemove', (event) =>
+      this.makeFollowMouse(event),
+    );
+  }
+
+  makeFollowMouse(event) {
+    if (this.throttling) {
+      this.lastPosition = calcPosition(event);
+      return;
+    }
+    this.throttling = true;
+    this.moveToMouse(calcPosition(event));
+    setTimeout(() => {
+      this.throttling = false;
+      if (this.lastPosition) {
+        this.moveToMouse(this.lastPosition);
+        this.lastPosition = null;
+      }
+    }, TIME.DUCK_THROTTLE);
   }
 
   moveToMouse(position) {

--- a/src/frontend/engine/DuckCursorObject.js
+++ b/src/frontend/engine/DuckCursorObject.js
@@ -26,21 +26,17 @@ class DuckCursorObject extends DuckObejct {
     this.attachToRoot();
     this.throttling = false;
     this.lastPosition = null;
-
+    this.mouseHandler = this.makeFollowMouse.bind(this);
     this.width = 100;
     this.render();
   }
 
   addMouseMoveEvent() {
-    $id('root').addEventListener('mousemove', (event) =>
-      this.makeFollowMouse(event),
-    );
+    $id('root').addEventListener('mousemove', this.mouseHandler);
   }
 
   removeMouseMoveEvent() {
-    $id('root').removeEventListener('mousemove', (event) =>
-      this.makeFollowMouse(event),
-    );
+    $id('root').removeEventListener('mousemove', this.mouseHandler);
   }
 
   makeFollowMouse(event) {

--- a/src/frontend/engine/DuckCursorObject.js
+++ b/src/frontend/engine/DuckCursorObject.js
@@ -18,7 +18,7 @@ const calcPosition = (event) => {
 };
 
 class DuckCursorObject extends DuckObejct {
-  constructor(props) {
+  constructor({ isReady, ...props }) {
     super(props);
     this.addClass('cursor-duck-wrapper');
     this.setOriginCenter();
@@ -29,6 +29,7 @@ class DuckCursorObject extends DuckObejct {
     this.mouseHandler = this.makeFollowMouse.bind(this);
     this.width = 100;
     this.render();
+    this.setVisibility(isReady);
   }
 
   addMouseMoveEvent() {
@@ -60,6 +61,18 @@ class DuckCursorObject extends DuckObejct {
     this.move(x, y, TIME.DUCK_SPEED);
 
     socket.emit('send duck move', { x, y });
+  }
+
+  setVisibility(value = false, isCurrentPlayer) {
+    const displayStyle = value ? 'block' : 'none';
+    this.instance.style.display = displayStyle;
+
+    if (isCurrentPlayer) this.setMouseEvent(value);
+  }
+
+  setMouseEvent(value = true) {
+    if (value) this.addMouseMoveEvent();
+    else this.removeMouseMoveEvent();
   }
 }
 

--- a/src/frontend/engine/DuckObject.js
+++ b/src/frontend/engine/DuckObject.js
@@ -21,10 +21,6 @@ class DuckObject extends GameObject {
     hatElement.style.display = display;
   }
 
-  setVisible(boolean) {
-    boolean ? this.removeClass('hide') : this.addClass('hide');
-  }
-
   generateDuckHTML() {
     const { color, width } = this;
     return `

--- a/src/frontend/game/game.js
+++ b/src/frontend/game/game.js
@@ -3,11 +3,8 @@ import socket from '@utils/socket';
 import { $id, $create } from '@utils/dom';
 import requestHandler from '@utils/requestHandler';
 import WaitingRoom from '@scenes/waitingRoom';
-import TellerSelectCard from '@scenes/tellerSelectCard';
-import GuesserWaiting from '@scenes/guesserWaiting';
 import SceneManager from '@utils/SceneManager';
 import PlayerManager from '@utils/PlayerManager';
-import CardManager from '@utils/CardManager';
 import TIME from '@type/time';
 import './LeftTab';
 import './background';
@@ -68,7 +65,6 @@ const initializeLayout = () => {
   });
 
   const logMessage = (args) => getMessageFromServer(args, chatMessageLog);
-
   socket.on('send chat', logMessage);
 };
 
@@ -85,29 +81,7 @@ const initialize = async () => {
 
   initializeLayout();
   SceneManager.renderNextScene(new WaitingRoom(roomID));
-
-  // initialize game event socket
-  socket.on('enter room', ({ nickname, players }) => {
-    PlayerManager.initialize(players);
-    PlayerManager.updateCurrentPlayer({ nickname });
-  });
-  socket.on('update player', ({ socketID, nickname, color }) => {
-    PlayerManager.set({ socketID, nickname, color });
-  });
-  socket.on('exit player', ({ socketID }) => {
-    PlayerManager.delete(socketID);
-  });
   socket.emit('join player', { roomID });
-  socket.on('get round data', ({ tellerID, cards, endTime }) => {
-    PlayerManager.setTellerID(tellerID);
-    CardManager.initailizeMyCards(cards);
-    const { isTeller } = PlayerManager.getCurrentPlayer();
-    const nextScene = isTeller
-      ? new TellerSelectCard({ cards, endTime })
-      : new GuesserWaiting({ endTime });
-    SceneManager.renderNextScene(nextScene);
-  });
-
   socket.on('get duck move', ({ x, y, playerID: socketID }) => {
     if (!PlayerManager.has(socketID)) return;
     const { duck } = PlayerManager.get(socketID);

--- a/src/frontend/scenes/guesserWaiting/render.js
+++ b/src/frontend/scenes/guesserWaiting/render.js
@@ -22,7 +22,9 @@ const renderGuesserWaiting = ({ endTime }) => {
   ProgressBar.setTime(endTime);
   ProgressBar.start();
 
-  PlayerManager.getPlayers().forEach((player) => player.duck.setVisible(false));
+  PlayerManager.getPlayers().forEach((player) =>
+    player.duck.setVisibility(false),
+  );
   const tellerColor = PlayerManager.getTeller().color;
   const TellerDuck = new DuckObject({ color: tellerColor, width: 200 });
   TellerDuck.addClass('teller-duck-wrapper');

--- a/src/frontend/scenes/playerWaiting/index.js
+++ b/src/frontend/scenes/playerWaiting/index.js
@@ -1,5 +1,4 @@
 import './style.scss';
-import TIME from '@type/time';
 import CardManager from '@utils/CardManager';
 import renderPlayerWaiting from './render';
 import setupPlayerWaiting from './socket';

--- a/src/frontend/scenes/waitingRoom/events.js
+++ b/src/frontend/scenes/waitingRoom/events.js
@@ -1,4 +1,5 @@
 import socket from '@utils/socket';
+import PlayerManager from '@utils/PlayerManager';
 import { testHexColorString } from '@utils/hexColor';
 
 export const redirectToLobby = () => {
@@ -24,13 +25,15 @@ export const changeNickname = (NicknameInput) => {
 };
 
 export const toggleReady = ({ target }) => {
-  const { isReady } = JSON.parse(target.dataset.data);
-  // const nextStatus = target.dataset.status === 'not ready';
+  const currentPlayer = PlayerManager.getCurrentPlayer();
+  const { isReady } = currentPlayer;
   const nextStatus = !isReady;
-  // target.dataset.status = nextStatus ? 'ready' : 'not ready';
-  target.dataset.data = JSON.stringify({ isReady: nextStatus });
+
+  target.innerText = nextStatus ? '준비 해제' : '준비 완료';
   target.classList.toggle('button-primary');
   target.classList.toggle('button-primary-clicked');
+
+  PlayerManager.getCurrentPlayer().setReady(nextStatus);
   socket.emit('ready player', { isReady: nextStatus });
 };
 

--- a/src/frontend/scenes/waitingRoom/socket.js
+++ b/src/frontend/scenes/waitingRoom/socket.js
@@ -1,6 +1,16 @@
 import socket from '@utils/socket';
+import PlayerManager from '@utils/PlayerManager';
+import SceneManager from '@utils/SceneManager';
+import CardManager from '@utils/CardManager';
+import TellerSelectCard from '@scenes/tellerSelectCard';
+import GuesserWaiting from '@scenes/guesserWaiting';
 
 const setupWaitingRoomSocket = ({ AllReadyText }) => {
+  const onEnterRoom = ({ nickname, players }) => {
+    PlayerManager.initialize(players);
+    PlayerManager.updateCurrentPlayer({ nickname });
+  };
+
   const onAllReady = () => {
     AllReadyText.removeClass('hide');
     AllReadyText.instance.animate(
@@ -20,8 +30,36 @@ const setupWaitingRoomSocket = ({ AllReadyText }) => {
     // TODO: 게임 시작 취소됐다는 메시지 띄워줘야됨~~
   };
 
+  const onUpdatePlayer = ({ socketID, nickname, color }) => {
+    PlayerManager.set({ socketID, nickname, color });
+  };
+
+  const onExitPlayer = ({ socketID }) => {
+    PlayerManager.delete(socketID);
+  };
+
+  const onReadyPlayer = ({ playerID, isReady }) => {
+    const player = PlayerManager.get(playerID);
+    if (player) player.setReady(isReady);
+  };
+
+  const onGetRoundData = ({ tellerID, cards, endTime }) => {
+    PlayerManager.setTellerID(tellerID);
+    CardManager.initailizeMyCards(cards);
+    const { isTeller } = PlayerManager.getCurrentPlayer();
+    const nextScene = isTeller
+      ? new TellerSelectCard({ cards, endTime })
+      : new GuesserWaiting({ endTime });
+    SceneManager.renderNextScene(nextScene);
+  };
+
+  socket.on('enter room', onEnterRoom);
+  socket.on('update player', onUpdatePlayer);
+  socket.on('exit player', onExitPlayer);
+  socket.on('ready player', onReadyPlayer);
   socket.on('all ready', onAllReady);
   socket.on('game start aborted', onGameStartAborted);
+  socket.on('get round data', onGetRoundData);
 };
 
 export default setupWaitingRoomSocket;

--- a/src/frontend/utils/Player.js
+++ b/src/frontend/utils/Player.js
@@ -8,6 +8,7 @@ const Player = class {
     score = 0,
     isTeller = false,
     isCurrentPlayer = false,
+    isReady = false,
   } = {}) {
     this.socketID = socketID;
     this.nickname = nickname;
@@ -15,9 +16,8 @@ const Player = class {
     this.score = score;
     this.isTeller = isTeller;
     this.isCurrentPlayer = isCurrentPlayer;
-    this.isReady = false;
-    this.duck = new DuckCursorObject({ color });
-    this.setVisibility(false);
+    this.isReady = isReady;
+    this.duck = new DuckCursorObject({ isReady, color });
   }
 
   update(params) {
@@ -33,22 +33,10 @@ const Player = class {
     this.duck.delete();
   }
 
-  setVisibility(value = false) {
-    const displayStyle = value ? 'block' : 'none';
-    this.duck.instance.style.display = displayStyle;
-
-    if (this.isCurrentPlayer) this.setMouseEvent(value);
-  }
-
-  setMouseEvent(value = true) {
-    if (value) this.duck.addMouseMoveEvent();
-    else this.duck.removeMouseMoveEvent();
-  }
-
   setReady(value) {
     if (this.isReady === value) return;
     this.isReady = value;
-    this.setVisibility(value);
+    this.duck.setVisibility(value, this.isCurrentPlayer);
   }
 };
 

--- a/src/frontend/utils/Player.js
+++ b/src/frontend/utils/Player.js
@@ -15,12 +15,9 @@ const Player = class {
     this.score = score;
     this.isTeller = isTeller;
     this.isCurrentPlayer = isCurrentPlayer;
+    this.isReady = false;
     this.duck = new DuckCursorObject({ color });
-
-    if (this.isCurrentPlayer) {
-      this.duck.makeFollowMouse();
-    } else {
-    }
+    this.setVisibility(false);
   }
 
   update(params) {
@@ -29,12 +26,29 @@ const Player = class {
       this[key] = params[key];
     });
 
-    // update player duck
     this.duck.setColor(this.color);
   }
 
   delete() {
     this.duck.delete();
+  }
+
+  setVisibility(value = false) {
+    const displayStyle = value ? 'block' : 'none';
+    this.duck.instance.style.display = displayStyle;
+
+    if (this.isCurrentPlayer) this.setMouseEvent(value);
+  }
+
+  setMouseEvent(value = true) {
+    if (value) this.duck.addMouseMoveEvent();
+    else this.duck.removeMouseMoveEvent();
+  }
+
+  setReady(value) {
+    if (this.isReady === value) return;
+    this.isReady = value;
+    this.setVisibility(value);
   }
 };
 


### PR DESCRIPTION
## 💁 설명

### DuckObject & PlayerManager 수정
- DuckObject에서는 바로 이벤트 등록을 해주고 있는데 보이지 않을 때 계속 리스너를 해줄 필요는 없을 것 같아서?! 일단 분리를 해두었습니다.
- visibility에 따라서 이벤트 등록 / 제거를 합니다.
- `ready player` 이벤트의 콜백으로 true일 때는 해당 오리를 보이게 false일 때는 보이지 않게 했습니다~

### 기존 플레이어의 프로필
- 이전에는 닉네임과 컬러만 받아왔다면 ready도 같이 넘겨줘서 만약 이전에 레디한 상태라면 처음 들어온 유저가 볼 수 있게 수정

### 일부 리팩토링
- game.js에 들어있던 소켓 이벤트 콜백함수들을 waitingroom 으로 이동했습니다.
- 기존 레디버튼 관리를 dataset으로 했는데 이거를 player로 ready상태 관리를 빼면서 player를 이용해서 했습니다~

![화면 기록 2020-12-10 오후 3 35 35 mov](https://user-images.githubusercontent.com/43198553/101730504-7a6c8000-3afd-11eb-8490-965c708aec5a.gif)

## 📑 체크리스트

> 구현한 목록 체크리스트
- [ ] 준비오리만 볼 수 있다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 주의 사항 1
- 주의 사항 2
