### PR TITLE
Teller Select ~ Player Waiting 씬별 오리 visible 관리

### DIFF
--- a/src/frontend/engine/DuckCursorObject.js
+++ b/src/frontend/engine/DuckCursorObject.js
@@ -63,7 +63,7 @@ class DuckCursorObject extends DuckObejct {
     socket.emit('send duck move', { x, y });
   }
 
-  setVisibility(value = false, isCurrentPlayer) {
+  setVisibility(value = false, isCurrentPlayer = false) {
     const displayStyle = value ? 'block' : 'none';
     this.instance.style.display = displayStyle;
 

--- a/src/frontend/engine/ProgressBarObject.js
+++ b/src/frontend/engine/ProgressBarObject.js
@@ -14,7 +14,7 @@ const ProgressBarObject = class extends GameObject {
 
   finish() {
     if (this.callback) this.callback();
-    this.instance.style.visibility = 'none';
+    this.instance.style.display = 'none';
   }
 
   createElement() {

--- a/src/frontend/engine/ProgressBarObject.js
+++ b/src/frontend/engine/ProgressBarObject.js
@@ -14,7 +14,7 @@ const ProgressBarObject = class extends GameObject {
 
   finish() {
     if (this.callback) this.callback();
-    this.remove();
+    this.instance.style.visibility = 'none';
   }
 
   createElement() {

--- a/src/frontend/scenes/guesserSelectCard/socket.js
+++ b/src/frontend/scenes/guesserSelectCard/socket.js
@@ -1,8 +1,8 @@
 import socket from '@utils/socket';
 import CardManager from '@utils/CardManager';
 import SceneManager from '@utils/SceneManager';
+import PlayerManager from '@utils/PlayerManager';
 import PlayerWaiting from '../playerWaiting';
-import PlayerManager from '../../utils/PlayerManager';
 
 const setupGuesserSelectCard = ({ ProgressBar, scene }) => {
   const onGuesserSelectCard = ({ cardID }) => {

--- a/src/frontend/scenes/guesserSelectCard/socket.js
+++ b/src/frontend/scenes/guesserSelectCard/socket.js
@@ -2,15 +2,19 @@ import socket from '@utils/socket';
 import CardManager from '@utils/CardManager';
 import SceneManager from '@utils/SceneManager';
 import PlayerWaiting from '../playerWaiting';
+import PlayerManager from '../../utils/PlayerManager';
 
 const setupGuesserSelectCard = ({ ProgressBar, scene }) => {
   const onGuesserSelectCard = ({ cardID }) => {
     CardManager.addSubmittedCardCount();
     CardManager.selectCard(cardID);
     SceneManager.renderNextScene(new PlayerWaiting({ ProgressBar }));
+
+    const myDuck = PlayerManager.getCurrentPlayer().duck;
+    myDuck.setVisibility(true, true);
   };
 
-  const onOtherGuesserSelectCard = ({ playerID }) => {
+  const onOtherGuesserSelectCard = () => {
     if (SceneManager.currentScene === scene) {
       CardManager.addSubmittedCardCount();
     }

--- a/src/frontend/scenes/guesserWaiting/render.js
+++ b/src/frontend/scenes/guesserWaiting/render.js
@@ -23,8 +23,9 @@ const renderGuesserWaiting = ({ endTime }) => {
   ProgressBar.start();
 
   PlayerManager.getPlayers().forEach((player) =>
-    player.duck.setVisibility(false),
+    player.duck.setVisibility(!player.isTeller, player.isCurrentPlayer),
   );
+
   const tellerColor = PlayerManager.getTeller().color;
   const TellerDuck = new DuckObject({ color: tellerColor, width: 200 });
   TellerDuck.addClass('teller-duck-wrapper');

--- a/src/frontend/scenes/playerWaiting/render.js
+++ b/src/frontend/scenes/playerWaiting/render.js
@@ -7,7 +7,11 @@ const renderPlayerWaiting = ({ ProgressBar, endTime }) => {
   const newProgressBar = new ProgressBarObject();
   newProgressBar.createElement();
 
-  if (PlayerManager.isTeller()) {
+  const isTeller = PlayerManager.isTeller();
+  const tellerDuck = PlayerManager.getTeller().duck;
+  tellerDuck.setVisibility(true, isTeller);
+
+  if (isTeller) {
     newProgressBar.attachToRoot();
     newProgressBar.setTime(endTime);
     newProgressBar.start();

--- a/src/frontend/scenes/playerWaiting/socket.js
+++ b/src/frontend/scenes/playerWaiting/socket.js
@@ -1,11 +1,14 @@
 import socket from '@utils/socket';
 import CardManager from '@utils/CardManager';
+import PlayerManager from '@utils/PlayerManager';
 import SceneManager from '@utils/SceneManager';
 import MixCard from '../mixCard';
 
 const setupPlayerWaiting = () => {
-  const onOtherGuesserSelectCard = () => {
+  const onOtherGuesserSelectCard = ({ playerID }) => {
     CardManager.dropNewCard();
+    const guesserDuck = PlayerManager.get(playerID).duck;
+    guesserDuck.setVisibility(true);
   };
 
   const onGetAllDecisions = ({ cards }) => {

--- a/src/frontend/scenes/tellerSelectCard/index.js
+++ b/src/frontend/scenes/tellerSelectCard/index.js
@@ -1,5 +1,5 @@
 import TIME from '@type/time';
-import CardManager from '../../utils/CardManager';
+import CardManager from '@utils/CardManager';
 import renderTellerSelect from './render';
 import setupTellerSelectSocket from './socket';
 

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -1,4 +1,5 @@
 import { $id } from '@utils/dom';
+import PlayerManager from '@utils/PlayerManager';
 import TIME from '@type/time';
 
 const root = $id('root');
@@ -8,6 +9,8 @@ const SceneManager = {
 
   renderNextScene(scene, ...args) {
     let wrapupInterval = TIME.NONE_INTERVAL;
+    this.removeAllDucks();
+
     if (this.currentScene) {
       this.currentScene.wrapup();
       wrapupInterval = this.currentScene.wrapupInterval || TIME.NONE_INTERVAL;
@@ -20,6 +23,13 @@ const SceneManager = {
 
   isCurrentScene(classObject) {
     return this.currentScene.constructor.name === classObject.name;
+  },
+
+  removeAllDucks() {
+    const players = PlayerManager.getPlayers();
+    players.forEach((player) =>
+      player.duck.setVisibility(false, player.isCurrentPlayer),
+    );
   },
 };
 

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -9,7 +9,7 @@ const SceneManager = {
 
   renderNextScene(scene, ...args) {
     let wrapupInterval = TIME.NONE_INTERVAL;
-    this.removeAllDucks();
+    this.hideAllDucks();
 
     if (this.currentScene) {
       this.currentScene.wrapup();
@@ -25,7 +25,7 @@ const SceneManager = {
     return this.currentScene.constructor.name === classObject.name;
   },
 
-  removeAllDucks() {
+  hideAllDucks() {
     const players = PlayerManager.getPlayers();
     players.forEach((player) =>
       player.duck.setVisibility(false, player.isCurrentPlayer),


### PR DESCRIPTION
## 💁 설명

### Guesser Waiting
- 모든 Guesser가 보인다
- Teller는 고르고 있으므로 보이지 않는다.

![화면 기록 2020-12-10 오후 5 30 40 mov](https://user-images.githubusercontent.com/43198553/101741705-aabc1a80-3b0d-11eb-9fa1-f0b049fa6049.gif)

### Player Waiting
- 이미 카드를 고른 텔러는 보인다.
- 카드를 선택한 Guesser는 보인다.
- Mix card 전에는 모두가 보인다.

![화면 기록 2020-12-10 오후 5 31 02 mov](https://user-images.githubusercontent.com/43198553/101741985-bad3fa00-3b0d-11eb-8f5a-374d3bb78fa5.gif)


### 그 외에 select 씬에서는 오리가 보이지 않음! 

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 위의 설명 참고!

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항


