### PR TITLE
0번 카드 버그 수정 (#126)

### DIFF
--- a/src/frontend/utils/card.js
+++ b/src/frontend/utils/card.js
@@ -12,7 +12,7 @@ export const createCards = (sceneName, cardIds = Array(6).fill(null)) => {
   emptyObject.addClass('teller-cards-wrapper');
   const cards = cardIds.map((cardID, index) => {
     const card = new CardObject({
-      imagePath: cardID ? GET_IMAGE_PATH(cardID) : undefined,
+      imagePath: GET_IMAGE_PATH(cardID),
       cardID,
     });
     card.addClass('teller-duck-card');


### PR DESCRIPTION
## 💁 설명

- cardID를 체크하는 부분이 있었는데 아이디는 항상 있을 것 같아서 그냥 바로 넘겨줌
- 0을 무시하지 말자.. 0은 falsy..

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 카드가 0번이어도 잘 보인다!

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- close #126 
