### PR TITLE
라운드 종료 화면

### DIFF
--- a/src/frontend/game/game.scss
+++ b/src/frontend/game/game.scss
@@ -45,8 +45,7 @@ $right-size: 330px;
     width: 100%;
     height: 100%;
     background-color: $white-color;
-    // transform: scale(0.6);
-    transition: transform 2s;
+    transition: transform 1s;
   }
 }
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -6984,6 +6984,49 @@
         }
       }
     },
+    "raw-loader": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+      "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -26,6 +26,7 @@
     "html-webpack-plugin": "^4.5.0",
     "mini-css-extract-plugin": "^1.3.1",
     "prettier": "2.1.2",
+    "raw-loader": "^4.0.2",
     "sass": "^1.29.0",
     "sass-loader": "^10.1.0",
     "style-loader": "^2.0.0",

--- a/src/frontend/scenes/scoreboard/index.js
+++ b/src/frontend/scenes/scoreboard/index.js
@@ -10,16 +10,33 @@ const Scoreboard = class {
     },
   ) {
     this.params = params;
+    this.animationTimeout = null;
   }
 
   render() {
     const players = PlayerManager.getPlayers();
 
-    const { arrayToBeRemoved } = renderScoreboard({ ...this.params, players });
+    const { arrayToBeRemoved, totalAnimationTime } = renderScoreboard({
+      ...this.params,
+      players,
+    });
     this.arrayToBeRemoved = arrayToBeRemoved;
+    this.animationTimeout = setTimeout(
+      this.afterAnimation.bind(this),
+      totalAnimationTime,
+    );
+  }
+
+  afterAnimation() {
+    this.animationTimeout = null;
+    // socket.emit('scoreboard animation ends');
   }
 
   wrapup() {
+    if (this.animationTimeout) {
+      this.afterAnimation();
+      clearTimeout(this.animationTimeout);
+    }
     this.arrayToBeRemoved.forEach((gameObject) => {
       gameObject.delete();
     });

--- a/src/frontend/scenes/scoreboard/index.js
+++ b/src/frontend/scenes/scoreboard/index.js
@@ -1,0 +1,29 @@
+import PlayerManager from '@utils/PlayerManager';
+import renderScoreboard from './render';
+
+const Scoreboard = class {
+  constructor(
+    params = {
+      round: 0,
+      scoreData: [],
+      isGameOver: true,
+    },
+  ) {
+    this.params = params;
+  }
+
+  render() {
+    const players = PlayerManager.getPlayers();
+
+    const { arrayToBeRemoved } = renderScoreboard({ ...this.params, players });
+    this.arrayToBeRemoved = arrayToBeRemoved;
+  }
+
+  wrapup() {
+    this.arrayToBeRemoved.forEach((gameObject) => {
+      gameObject.delete();
+    });
+  }
+};
+
+export default Scoreboard;

--- a/src/frontend/scenes/scoreboard/render.js
+++ b/src/frontend/scenes/scoreboard/render.js
@@ -1,0 +1,28 @@
+import GameObject from '@engine/GameObject';
+import './style.scss';
+import template from './template.html';
+
+const renderScoreboardLayout = ({ round, players, scoreData } = {}) => {
+  const templateWrapper = document.createElement('div');
+  templateWrapper.innerHTML = template;
+
+  const Background = new GameObject();
+  Background.instance = templateWrapper.firstChild;
+  Background.attachToRoot();
+
+  Background.instance.querySelector(
+    '#scoreboard-title',
+  ).innerText = `Round ${round} 획득 점수`;
+
+  const TableBody = new GameObject();
+  TableBody.instance = Background.instance.querySelector(
+    '#scoreboard-table-body',
+  );
+
+  const arrayToBeRemoved = [Background];
+  return {
+    arrayToBeRemoved,
+  };
+};
+
+export default renderScoreboardLayout;

--- a/src/frontend/scenes/scoreboard/render.js
+++ b/src/frontend/scenes/scoreboard/render.js
@@ -6,12 +6,10 @@ import stonePosition from '@type/stonePosition.json';
 import './style.scss';
 import template from './template.html';
 
-const renderRow = (TableBody) => ({
+const defineRenderRow = (TableBody) => ({
   nickname,
   color,
   isTeller,
-  isCurrentPlayer,
-  score: currentScore,
   correctScore,
   bonusScore,
   totalScore,
@@ -46,6 +44,10 @@ const renderRow = (TableBody) => ({
     classes: ['scoreboard-table-score'],
     parent: TableRow,
   }).setContent(`${totalScore}`);
+};
+
+const renderRow = (TableBody, players) => {
+  players.forEach(defineRenderRow(TableBody));
 };
 
 const getMaximumScoreDifference = (players) =>
@@ -127,6 +129,7 @@ const renderScoreboardLayout = ({
   }));
   const totalAnimationTime = getTotalAnimationTime(playersWithScore);
 
+  renderRow(TableBody, playersWithScore);
   animateBackground(playersWithScore, totalAnimationTime, isGameOver);
 
   const arrayToBeRemoved = [Background];

--- a/src/frontend/scenes/scoreboard/render.js
+++ b/src/frontend/scenes/scoreboard/render.js
@@ -1,6 +1,50 @@
 import GameObject from '@engine/GameObject';
+import DuckObject from '@engine/DuckObject';
+import TextObject from '@engine/TextObject';
 import './style.scss';
 import template from './template.html';
+
+const renderRow = (TableBody) => ({
+  nickname,
+  color,
+  isTeller,
+  isCurrentPlayer,
+  score: currentScore,
+  correctScore,
+  bonusScore,
+  totalScore,
+} = {}) => {
+  const TableRow = new GameObject({
+    classes: ['scoreboard-table-row'],
+    parent: TableBody,
+  });
+  const PlayerInfoWrapper = new GameObject({
+    classes: ['scoreboard-table-player'],
+    parent: TableRow,
+  });
+  const DuckIcon = new DuckObject({
+    color,
+    width: 60,
+    parent: PlayerInfoWrapper,
+  });
+  DuckIcon.setHat(isTeller);
+  const NicknameObject = new TextObject({
+    parent: PlayerInfoWrapper,
+  }).setContent(nickname);
+
+  const CorrectScoreObject = new TextObject({
+    classes: ['scoreboard-table-score'],
+    parent: TableRow,
+  }).setContent(`+${correctScore}`);
+  const BonusScoreObject = new TextObject({
+    classes: ['scoreboard-table-score'],
+    parent: TableRow,
+  }).setContent(`+${bonusScore}`);
+  const TotalScoreObject = new TextObject({
+    classes: ['scoreboard-table-score'],
+    parent: TableRow,
+  }).setContent(`${totalScore}`);
+};
 
 const renderScoreboardLayout = ({ round, players, scoreData } = {}) => {
   const templateWrapper = document.createElement('div');
@@ -18,6 +62,14 @@ const renderScoreboardLayout = ({ round, players, scoreData } = {}) => {
   TableBody.instance = Background.instance.querySelector(
     '#scoreboard-table-body',
   );
+
+  const playersWithScore = players.map((player) => ({
+    ...player,
+    ...scoreData.find((data) => data.socketID === player.socketID),
+  }));
+  const renderRowInTableBody = renderRow(TableBody);
+
+  playersWithScore.forEach(renderRowInTableBody);
 
   const arrayToBeRemoved = [Background];
   return {

--- a/src/frontend/scenes/scoreboard/style.scss
+++ b/src/frontend/scenes/scoreboard/style.scss
@@ -1,0 +1,56 @@
+.scoreboard-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  justify-content: center;
+  padding: 5rem 15rem 10rem;
+  backdrop-filter: blur(4px);
+  background-color: #eeea;
+  text-align: center;
+}
+
+.scoreboard-title {
+  margin-bottom: 1em;
+  font-size: xx-large;
+}
+
+.scoreboard-table {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.scoreboard-table-row {
+  display: flex;
+  align-items: center;
+  padding-top: 0.5rem;
+}
+
+.scoreboard-table-player {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  word-wrap: break-word;
+
+  > div {
+    margin-right: 1rem;
+  }
+}
+
+.scoreboard-table-score {
+  width: 5rem;
+}
+
+.scoreboard-table-body {
+  display: flex;
+  flex-direction: column;
+
+  .scoreboard-table-score {
+    font-size: xx-large;
+    font-weight: bold;
+  }
+}

--- a/src/frontend/scenes/scoreboard/template.html
+++ b/src/frontend/scenes/scoreboard/template.html
@@ -1,0 +1,13 @@
+<div class="scoreboard-background">
+  <div id="scoreboard-title" class="scoreboard-title"></div>
+  <div class="scoreboard-table">
+    <div class="scoreboard-table-row scoreboard-table-header">
+      <div class="scoreboard-table-player"></div>
+      <div class="scoreboard-table-score">정답점수</div>
+      <div class="scoreboard-table-score">보너스점수</div>
+      <div class="scoreboard-table-score">총점</div>
+    </div>
+    <div id="scoreboard-table-body" class="scoreboard-table-body">
+    </div>
+  </div>
+</div>

--- a/src/frontend/utils/dom.js
+++ b/src/frontend/utils/dom.js
@@ -1,3 +1,6 @@
 export const $qs = document.querySelector.bind(document);
 export const $id = document.getElementById.bind(document);
 export const $create = (tag) => document.createElement(tag);
+
+export const ROOT = $id('root');
+export const BACKGROUND = $id('background');

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -96,6 +96,10 @@ module.exports = (webpackEnv) => {
             publicPath: 'assets',
           },
         },
+        {
+          test: /\.html$/i,
+          use: 'raw-loader',
+        },
       ],
     },
     ...(isEnvDevelopment


### PR DESCRIPTION
## 💁 설명

![GIF 2020-12-10 오후 10-22-12](https://user-images.githubusercontent.com/48747221/101778132-cbe53100-3b36-11eb-9b0a-3f8da31c148f.gif)

소년점프? 이젠 **오리점프**🐥🐤🐥🐤

## 체크리스트
- 표 레이아웃/스타일링
- background에 오리 배치
- animation 구현
- animation이 끝난 뒤의 액션을 취할 수 있는 기반을 다져둠

백엔드 작업은 없었습니다. 다만 소켓 명세를 바꾸고싶다는 생각이 들어서 밑에다 달아둡니다.

## 기술적인 이야기
### html template를 활용해 레이아웃 작성
- 전부 다 GameObject를 사용해서 작성하려면 진짜 힘들것같아서 *더이상은 못참아* 한번 외쳐준다음 html template를 사용했습니다. 
- html template를 사용하기 위해 webpack에 raw-loader를 추가했습니다. 이 머지가 빌드되면 프론트엔드에서 `npm ci`를 한번 쳐주실 필요가 있습니다.
- 기존 GameEngine에서 template를 활용하기 위해 억지로 instance를 끄집어내서 사용한게 많습니다. template 사용이 편하다 싶으면 이런걸 다 GameEngine의 메소드로 만들어 리팩토링하는 것도 좋을 것 같아요.

### 애니메이션 타이밍 관련
- 믹스카드를 만들면서 진혁님이 느끼셨을 고충이 그대로 전해져왔습니다. 애니메이션 시작과 끝을 어떻게 관리할지... 참 난감한 작업이었습니다.
- 진짜 시간관리하는부분 `동작은 하지만 어색한 코드`로 만들었는데... 이거 설명하느라고 PR로 정리하다보니까 지금 짠 코드보다 좋은 방법이 생각이 나서 이슈로 남겨둘 예정입니다. 이슈 남기면 여기 PR에 코멘트 남길게요. 지금 있는 타이밍 관련 코드들은 아 그냥 대충 흘겨봐주세요.

## ⚠ 주의사항
새 dependency가 추가된 것이므로 이 PR이 머지되면 프론트엔드에 `npm ci` 돌려야됩니다 !!
