### PR TITLE
Progress bar 중복으로 렌더되는 버그 해결

### DIFF
--- a/src/frontend/engine/ProgressBarObject.js
+++ b/src/frontend/engine/ProgressBarObject.js
@@ -17,6 +17,10 @@ const ProgressBarObject = class extends GameObject {
 
   finish() {
     if (this.callback) this.callback();
+    clearInterval(this.progressBarTimer);
+    clearTimeout(this.timeOutlManager);
+    this.progressBarTimer = null;
+    this.timeOutlManager = null;
     this.addClass('hide');
   }
 
@@ -44,7 +48,7 @@ const ProgressBarObject = class extends GameObject {
     this.removeClass('hide');
     const [progressBar, timeText] = this.getProgessBar();
     const { endTime } = this;
-    const progressBarTimer = setInterval(() => {
+    this.progressBarTimer = setInterval(() => {
       const remainTime = endTime - new Date().getTime();
       const widthSize = (remainTime / this.time) * 100;
       progressBar.style.width = `${widthSize}%`;
@@ -53,11 +57,13 @@ const ProgressBarObject = class extends GameObject {
       timeText.innerText = (remainTime / 1000).toFixed(0);
     }, TIME.HALF_SECOND);
 
-    const intervalManager = setTimeout(() => {
-      clearInterval(progressBarTimer);
-      clearTimeout(intervalManager);
+    this.timeOutManager = setTimeout(() => {
       this.finish();
     }, this.time);
+  }
+
+  clear() {
+    if (this.progressBarTimer) this.finish();
   }
 
   remove() {

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -35,9 +35,11 @@ const SceneManager = {
   },
 
   renderNextScene(scene, ...args) {
+    const { ProgressBar } = this.sharedComponents;
     let wrapupInterval = TIME.NONE_INTERVAL;
     this.hideAllDucks();
 
+    if (ProgressBar.progressBarTimer) ProgressBar.clear();
     if (this.currentScene) {
       this.currentScene.wrapup();
       wrapupInterval = this.currentScene.wrapupInterval || TIME.NONE_INTERVAL;


### PR DESCRIPTION
## 💁 설명

- interval, timeout 모두 클리어하게 수정
- 단 `guesser select card` => `player waiting`으로 넘어갈 때는 클리어하지 않음 `passingTimerClear`

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 버그를 잘 수정한다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 주의 사항 1
- 주의 사항 2
