### PR TITLE
Vote 씬 구현

### DIFF
--- a/src/frontend/scenes/vote/events.js
+++ b/src/frontend/scenes/vote/events.js
@@ -1,0 +1,28 @@
+import socket from '@utils/socket';
+import CardManager from '@utils/CardManager';
+import { $id } from '@utils/dom';
+
+const calcPosition = (event) => {
+  const { clientX: cursorX, clientY: cursorY } = event;
+  const root = $id('root');
+  const { x: rootX, y: rootY, width, height } = root.getBoundingClientRect();
+  const x = ((cursorX - rootX) / width) * 100;
+  const y = ((cursorY - rootY) / height) * 100;
+
+  return { x, y };
+};
+
+/* eslint-disable
+ import/prefer-default-export */
+export const sendVoteResult = ({ cardID, DuckStamp, event }) => {
+  if (CardManager.votedCard === cardID) {
+    CardManager.voteCard(null);
+    DuckStamp.addClass('hide');
+  } else {
+    const { x, y } = calcPosition(event);
+    CardManager.voteCard(cardID);
+    DuckStamp.removeClass('hide');
+    DuckStamp.move(x, y, 0);
+  }
+  socket.emit('vote card', { cardID: CardManager.votedCard });
+};

--- a/src/frontend/scenes/vote/index.js
+++ b/src/frontend/scenes/vote/index.js
@@ -1,0 +1,22 @@
+import './vote.scss';
+import renderVote from './render';
+
+const Vote = class {
+  constructor({ endTime }) {
+    this.endTime = endTime;
+  }
+
+  render() {
+    const { endTime } = this;
+    const { arrayToBeRemoved = [] } = renderVote({ endTime });
+    this.arrayToBeRemoved = arrayToBeRemoved;
+  }
+
+  wrapup() {
+    this.arrayToBeRemoved.forEach((gameObject) => {
+      gameObject.delete();
+    });
+  }
+};
+
+export default Vote;

--- a/src/frontend/scenes/vote/render.js
+++ b/src/frontend/scenes/vote/render.js
@@ -1,0 +1,46 @@
+import './vote.scss';
+import TextObject from '@engine/TextObject';
+import SceneManager from '@utils/SceneManager';
+import CardManager from '@utils/CardManager';
+import TEXT from '@utils/text';
+import DuckObject from '@engine/DuckObject';
+import PlayerManager from '@utils/PlayerManager';
+import { sendVoteResult } from './events';
+
+const renderDiscussion = ({ endTime }) => {
+  const { ProgressBar } = SceneManager.sharedComponents;
+  const cards = CardManager.submittedCards;
+
+  const { color } = PlayerManager.getCurrentPlayer();
+  const DuckStamp = new DuckObject({ width: 30, color });
+  DuckStamp.render();
+  DuckStamp.instance.style.borderColor = color;
+  DuckStamp.setOriginCenter();
+  DuckStamp.addClass(['hide', 'movable', 'duck-stamp']);
+  DuckStamp.attachToRoot();
+
+  if (!PlayerManager.isTeller()) {
+    cards.forEach((card) => {
+      card.addClass(['card-glow-gold-hover', 'hover-larger']);
+      card.addClickHandler((event) =>
+        sendVoteResult({ cardID: card.cardID, DuckStamp, event }),
+      );
+    });
+  }
+
+  ProgressBar.setTime(endTime);
+  ProgressBar.start();
+
+  const HelpText = new TextObject();
+  HelpText.addClass('helper-text');
+  HelpText.setContent(TEXT.VOTE.TITLE);
+  HelpText.attachToRoot();
+
+  const arrayToBeRemoved = [DuckStamp];
+
+  return {
+    arrayToBeRemoved,
+  };
+};
+
+export default renderDiscussion;

--- a/src/frontend/scenes/vote/vote.scss
+++ b/src/frontend/scenes/vote/vote.scss
@@ -1,0 +1,6 @@
+.duck-stamp {
+  padding: 5px;
+  border: 2px solid #a00;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 100%;
+}

--- a/src/frontend/socket/index.js
+++ b/src/frontend/socket/index.js
@@ -5,6 +5,7 @@ import setupGuesserSelectCard from './guesserSelectCard';
 import setupPlayerWaiting from './playerWaiting';
 import setupMixCard from './mixCard';
 import setupDiscussion from './discussion';
+import setupVote from './vote';
 
 const SocketManager = {
   initializeSocketOn() {
@@ -15,6 +16,7 @@ const SocketManager = {
     setupPlayerWaiting();
     setupMixCard();
     setupDiscussion();
+    setupVote();
   },
 };
 

--- a/src/frontend/socket/vote.js
+++ b/src/frontend/socket/vote.js
@@ -1,0 +1,5 @@
+import socket from '@utils/socket';
+
+const setupVote = () => {};
+
+export default setupVote;

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -10,6 +10,7 @@ const CardManager = class {
     this.topic = null;
     this.submittedCards = [];
     this.beforeSubmittedCount = 0;
+    this.votedCard = null;
   }
 
   initailizeMyCards(cards) {
@@ -22,6 +23,10 @@ const CardManager = class {
 
   selectCard(selectedCard) {
     this.selectedCard = selectedCard;
+  }
+
+  voteCard(votedCard) {
+    this.votedCard = votedCard;
   }
 
   removeSelectedCard() {

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -1,6 +1,5 @@
 import TextObject from '@engine/TextObject';
 import ProgressBarObject from '@engine/ProgressBarObject';
-import GuesserSelectCard from '@scenes/guesserSelectCard';
 import { $id } from '@utils/dom';
 import PlayerManager from '@utils/PlayerManager';
 import TIME from '@type/time';

--- a/src/frontend/utils/common.scss
+++ b/src/frontend/utils/common.scss
@@ -53,6 +53,18 @@ html {
   box-shadow: 0 0 4em 1em $white-color;
 }
 
+.helper-text {
+  @include helper-text-white-background;
+  position: absolute;
+  z-index: $z-index-layouts;
+  top: 25%;
+  left: 50%;
+  font-size: x-large;
+  text-align: center;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
 @mixin button {
   display: flex;
   flex-direction: row;
@@ -120,6 +132,7 @@ html {
   @include card-glow-hover;
   &:hover {
     box-shadow: $glow-color-gold;
+    cursor: pointer;
   }
 }
 

--- a/src/frontend/utils/text.js
+++ b/src/frontend/utils/text.js
@@ -37,6 +37,9 @@ const TEXT = {
     WARNING: '한 번 Skip을 누르면 취소할 수 없어요! 신중하게 선택하세요!',
     SKIP: '모든 유저가 스킵했으므로 잠시 후 투표로 넘어갑니다.',
   },
+  VOTE: {
+    TITLE: '자신이 생각하는 이야기꾼의 카드에 투표해주세요!',
+  },
 };
 
 export const GET_IMAGE_PATH = (cardID) => {


### PR DESCRIPTION
## 💁 설명

### Vote Scene 클래스 생성
- `render` : 먼저 `DuckStamp` 오브젝트 생성, 텔러가 아니면 카드 클릭 이벤트 핸들러 추가 => duck stamp 컨트롤
- 카드를 클릭한 위치에 duck stamp가 생긴다. => emit `vote card`
- Card Manager에서 votedCard를 관리 => 이미 선택한 카드와 클릭한 카드가 같으면 해제 | 아니면 선택

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] Vote 씬에서 원하는 카드에 투표할 수 있다.
- [ ] 이미 선택한 카드를 해제할 수 있다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- `calcPosition` : 민성 -> 해람님이 이미 짜신 함수인데 코드 한 줄 변경을 위해 일단 새로 추가를 했습니다. 
  - 추후 중복되는 코드를 없애고 리팩토링 필요!
- `helper-text` : 헬퍼 텍스트 클래스를 만들었는데 추후 비슷한 텍스트 오브젝트 클래스를 다 동일하게 변경