### PR TITLE
end game scene 레이아웃/스타일링/소켓 이벤트

### DIFF
--- a/src/frontend/engine/GameObject.js
+++ b/src/frontend/engine/GameObject.js
@@ -102,6 +102,14 @@ const GameObject = class {
     this.instance.innerHTML = html;
   }
 
+  getObjectsByIds(...ids) {
+    return ids.map((id) => {
+      const object = new GameObject();
+      object.instance = this.instance.querySelector(`#${id}`);
+      return object;
+    });
+  }
+
   transform() {
     this.instance.style.transform = `${this.rotateStyle} ${this.originStyle}`;
   }

--- a/src/frontend/scenes/endGame/index.js
+++ b/src/frontend/scenes/endGame/index.js
@@ -1,8 +1,18 @@
+import PlayerManager from '@utils/PlayerManager';
 import renderScoreboard from './render';
 
 const Scoreboard = class {
+  constructor({ winnerID } = {}) {
+    this.winnerID = winnerID;
+  }
+
   render() {
-    const { arrayToBeRemoved } = renderScoreboard();
+    const players = PlayerManager.getPlayers();
+
+    const { arrayToBeRemoved } = renderScoreboard({
+      players,
+      winnerID: this.winnerID,
+    });
     this.arrayToBeRemoved = arrayToBeRemoved;
   }
 

--- a/src/frontend/scenes/endGame/index.js
+++ b/src/frontend/scenes/endGame/index.js
@@ -1,7 +1,7 @@
 import PlayerManager from '@utils/PlayerManager';
 import renderScoreboard from './render';
 
-const Scoreboard = class {
+const EndGame = class {
   constructor({ winnerID } = {}) {
     this.winnerID = winnerID;
   }
@@ -23,4 +23,4 @@ const Scoreboard = class {
   }
 };
 
-export default Scoreboard;
+export default EndGame;

--- a/src/frontend/scenes/endGame/index.js
+++ b/src/frontend/scenes/endGame/index.js
@@ -1,0 +1,16 @@
+import renderScoreboard from './render';
+
+const Scoreboard = class {
+  render() {
+    const { arrayToBeRemoved } = renderScoreboard();
+    this.arrayToBeRemoved = arrayToBeRemoved;
+  }
+
+  wrapup() {
+    this.arrayToBeRemoved.forEach((gameObject) => {
+      gameObject.delete();
+    });
+  }
+};
+
+export default Scoreboard;

--- a/src/frontend/scenes/endGame/render.js
+++ b/src/frontend/scenes/endGame/render.js
@@ -1,0 +1,33 @@
+import GameObject from '@engine/GameObject';
+import './style.scss';
+import template from './template.html';
+
+const renderScoreboardLayout = () => {
+  const templateWrapper = document.createElement('div');
+  templateWrapper.innerHTML = template;
+
+  const Background = new GameObject();
+  Background.instance = templateWrapper.firstChild;
+  Background.attachToRoot();
+
+  const [
+    rowDucks,
+    rowNicknames,
+    rowScores,
+    buttonGoMain,
+    buttonRestart,
+  ] = Background.getObjectsByIds(
+    'end-ducks',
+    'end-nicknames',
+    'end-scores',
+    'end-button-go-main',
+    'end-button-restart',
+  );
+
+  const arrayToBeRemoved = [Background];
+  return {
+    arrayToBeRemoved,
+  };
+};
+
+export default renderScoreboardLayout;

--- a/src/frontend/scenes/endGame/render.js
+++ b/src/frontend/scenes/endGame/render.js
@@ -1,8 +1,28 @@
 import GameObject from '@engine/GameObject';
+import TextObject from '@engine/TextObject';
 import './style.scss';
 import template from './template.html';
 
-const renderScoreboardLayout = () => {
+const renderPlayerGrid = (rowDucks, rowNicknames, rowScores, winnerID) => (
+  player,
+) => {
+  const { socketID, nickname, score } = player;
+  const isWinner = winnerID === socketID;
+  const Duck = player.makeDuck({
+    classes: ['end-grid-item', isWinner && 'end-grid-winner'].filter(Boolean),
+    parent: rowDucks,
+  });
+  const Nickname = new TextObject({
+    classes: ['end-grid-item', isWinner && 'end-grid-winner'].filter(Boolean),
+    parent: rowNicknames,
+  }).setContent(nickname);
+  const Score = new TextObject({
+    classes: ['end-grid-item', isWinner && 'end-grid-winner'].filter(Boolean),
+    parent: rowScores,
+  }).setContent(score);
+};
+
+const renderScoreboardLayout = ({ players, winnerID } = {}) => {
   const templateWrapper = document.createElement('div');
   templateWrapper.innerHTML = template;
 
@@ -22,6 +42,10 @@ const renderScoreboardLayout = () => {
     'end-scores',
     'end-button-go-main',
     'end-button-restart',
+  );
+
+  players.forEach(
+    renderPlayerGrid(rowDucks, rowNicknames, rowScores, winnerID),
   );
 
   const arrayToBeRemoved = [Background];

--- a/src/frontend/scenes/endGame/style.scss
+++ b/src/frontend/scenes/endGame/style.scss
@@ -29,8 +29,36 @@
   }
 }
 
+.end-grid-item {
+  flex-basis: 0;
+  margin-bottom: 0.5em;
+}
+.end-grid-item:not(.end-grid-winner) {
+  flex-grow: 1;
+}
+.end-grid-item.end-grid-winner {
+  flex-grow: 1.5;
+  > div {
+    padding-top: 25%;
+
+    filter: drop-shadow(0 0 10px $main-color);
+    transform: scale(1.5);
+    transform-origin: bottom;
+  }
+}
+
 .end-ducks {
   align-items: flex-end;
+}
+
+.end-nicknames {
+  align-items: center;
+  font-size: x-large;
+}
+
+.end-scores {
+  align-items: center;
+  font-size: xxx-large;
 }
 
 .end-actions-wrapper {

--- a/src/frontend/scenes/endGame/style.scss
+++ b/src/frontend/scenes/endGame/style.scss
@@ -1,0 +1,42 @@
+@import '@utils/common';
+
+.end-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  padding: 5rem 15rem;
+  backdrop-filter: blur(4px);
+  background-color: #eeea;
+  text-align: center;
+}
+
+.end-title {
+  margin-bottom: 2em;
+  font-size: xxx-large;
+}
+
+.end-grid {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  > div {
+    display: flex;
+    justify-content: space-around;
+  }
+}
+
+.end-ducks {
+  align-items: flex-end;
+}
+
+.end-actions-wrapper {
+  display: flex;
+  align-self: flex-end;
+  > * {
+    margin-left: 1em;
+  }
+}

--- a/src/frontend/scenes/endGame/style.scss
+++ b/src/frontend/scenes/endGame/style.scss
@@ -41,6 +41,7 @@
   > div {
     padding-top: 25%;
 
+    animation: emphasizeDuck 1s cubic-bezier(0.19, 1, 0.22, 1);
     filter: drop-shadow(0 0 10px $main-color);
     transform: scale(1.5);
     transform-origin: bottom;
@@ -66,5 +67,14 @@
   align-self: flex-end;
   > * {
     margin-left: 1em;
+  }
+}
+
+@keyframes emphasizeDuck {
+  5% {
+    transform: rotateZ(-5deg) scale(2.5);
+  }
+  90% {
+    transform: scale(1.4);
   }
 }

--- a/src/frontend/scenes/endGame/template.html
+++ b/src/frontend/scenes/endGame/template.html
@@ -1,0 +1,12 @@
+<div class="end-background">
+  <div class="end-title">게임 결과!</div>
+  <div class="end-grid">
+    <div id="end-ducks" class="end-ducks"></div>
+    <div id="end-nicknames" class="end-nicknames"></div>
+    <div id="end-scores" class="end-scores"></div>
+  </div>
+  <div class="end-actions-wrapper">
+    <button id="end-button-go-main" class="button-cancel">메인으로 돌아가기</button>
+    <button id="end-button-restart" class="button-primary">다시하기</button>
+  </div>
+</div>

--- a/src/frontend/socket/endGame.js
+++ b/src/frontend/socket/endGame.js
@@ -1,0 +1,15 @@
+import socket from '@utils/socket';
+import SceneManager from '@utils/SceneManager';
+import Scoreboard from '@scenes/scoreboard';
+import EndGame from '@scenes/endGame';
+
+const onGameOver = (...args) => {
+  if (!SceneManager.isCurrentScene(Scoreboard)) return;
+  SceneManager.renderNextScene(new EndGame(...args));
+};
+
+const setupEndGameSocket = () => {
+  socket.on('game over', onGameOver);
+};
+
+export default setupEndGameSocket;

--- a/src/frontend/socket/index.js
+++ b/src/frontend/socket/index.js
@@ -5,6 +5,7 @@ import setupGuesserSelectCard from './guesserSelectCard';
 import setupPlayerWaiting from './playerWaiting';
 import setupMixCard from './mixCard';
 import setupDiscussion from './discussion';
+import setupEndGameSocket from './endGame';
 
 const SocketManager = {
   initializeSocketOn() {
@@ -15,6 +16,7 @@ const SocketManager = {
     setupPlayerWaiting();
     setupMixCard();
     setupDiscussion();
+    setupEndGameSocket();
   },
 };
 

--- a/src/frontend/utils/Player.js
+++ b/src/frontend/utils/Player.js
@@ -1,3 +1,4 @@
+import DuckObject from '@engine/DuckObject';
 import DuckCursorObject from '@engine/DuckCursorObject';
 
 const Player = class {
@@ -18,6 +19,10 @@ const Player = class {
     this.isCurrentPlayer = isCurrentPlayer;
     this.isReady = isReady;
     this.duck = new DuckCursorObject({ isReady, color });
+  }
+
+  makeDuck(options = {}) {
+    return new DuckObject({ color: this.color, ...options });
   }
 
   update(params) {


### PR DESCRIPTION
## 💁 설명

![GIF 2020-12-14 오후 6-08-31](https://user-images.githubusercontent.com/48747221/102063808-d9056700-3e39-11eb-9a20-9629551328f1.gif)

버튼 이벤트 (로비로 돌아가기/다시하기) 는 미구현이요~


## 편의 기능 추가

### GameObject.getObjectsByIds()
- html 템플레이트로 만든 GameObject에서 내부 dom에 id로 접근하는 과정을 method로 간략화.
- 추후 waitingRoom같이 레이아웃이 많은 페이지를 template로 refactor하면 이 method를 잘 써먹을 수 있으리라 예상됨
- 사용법은 `scenes/endGame/render.js` 코드 참고

`getElementById`가 아닌 `querySelector`로 구현하였음. 그 이유는 `getElementById`는 document에만 정의되어있고 element는 `querySelector`밖에 사용할 수 없기 때문. 
성능은 `document.getElementById`가 좋은데 같은 document 내에 id가 같은 다른 element가 섞여있다면 예상과 다른 결과값을 return받게됨...
그냥 id가 unique하다는 전제를 깔고 `document.getElementById`를 써야할지 고민되는 부분

### Player.makeDuck()
- player의 color나 isTeller를 활용해서 오리를 복사해낼 수 있는 method
- 추후 scoreboard의 refactor에서 써먹을 수 있으리라 예상됨

## 논의되지 않은 부분
- "다시하기" 버튼을 누르면 정확히 어떤 플로우를 따라가야할지 모르겠어요.