### PR TITLE
Vote Result 씬 구현

### DIFF
--- a/src/frontend/engine/DuckCursorObject.js
+++ b/src/frontend/engine/DuckCursorObject.js
@@ -1,21 +1,8 @@
 import socket from '@utils/socket';
 import { $id } from '@utils/dom';
+import { calcAbsolutePosFromRoot } from '@utils/calculate';
 import TIME from '@type/time';
 import DuckObejct from './DuckObject';
-
-const calcPosition = (event) => {
-  const { clientX: cursorX, clientY: cursorY, currentTarget } = event;
-  const {
-    x: rootX,
-    y: rootY,
-    width,
-    height,
-  } = currentTarget.getBoundingClientRect();
-  const x = ((cursorX - rootX) / width) * 100;
-  const y = ((cursorY - rootY) / height) * 100;
-
-  return { x, y };
-};
 
 class DuckCursorObject extends DuckObejct {
   constructor({ isReady, ...props }) {
@@ -42,11 +29,11 @@ class DuckCursorObject extends DuckObejct {
 
   makeFollowMouse(event) {
     if (this.throttling) {
-      this.lastPosition = calcPosition(event);
+      this.lastPosition = calcAbsolutePosFromRoot(event);
       return;
     }
     this.throttling = true;
-    this.moveToMouse(calcPosition(event));
+    this.moveToMouse(calcAbsolutePosFromRoot(event));
     setTimeout(() => {
       this.throttling = false;
       if (this.lastPosition) {

--- a/src/frontend/scenes/vote/events.js
+++ b/src/frontend/scenes/vote/events.js
@@ -1,16 +1,6 @@
 import socket from '@utils/socket';
 import CardManager from '@utils/CardManager';
-import { $id } from '@utils/dom';
-
-const calcPosition = (event) => {
-  const { clientX: cursorX, clientY: cursorY } = event;
-  const root = $id('root');
-  const { x: rootX, y: rootY, width, height } = root.getBoundingClientRect();
-  const x = ((cursorX - rootX) / width) * 100;
-  const y = ((cursorY - rootY) / height) * 100;
-
-  return { x, y };
-};
+import { calcAbsolutePosFromRoot } from '@utils/calculate';
 
 /* eslint-disable
  import/prefer-default-export */
@@ -19,7 +9,7 @@ export const sendVoteResult = ({ cardID, DuckStamp, event }) => {
     CardManager.voteCard(null);
     DuckStamp.addClass('hide');
   } else {
-    const { x, y } = calcPosition(event);
+    const { x, y } = calcAbsolutePosFromRoot(event);
     CardManager.voteCard(cardID);
     DuckStamp.removeClass('hide');
     DuckStamp.move(x, y, 0);

--- a/src/frontend/scenes/vote/events.js
+++ b/src/frontend/scenes/vote/events.js
@@ -1,0 +1,28 @@
+import socket from '@utils/socket';
+import CardManager from '@utils/CardManager';
+import { $id } from '@utils/dom';
+
+const calcPosition = (event) => {
+  const { clientX: cursorX, clientY: cursorY } = event;
+  const root = $id('root');
+  const { x: rootX, y: rootY, width, height } = root.getBoundingClientRect();
+  const x = ((cursorX - rootX) / width) * 100;
+  const y = ((cursorY - rootY) / height) * 100;
+
+  return { x, y };
+};
+
+/* eslint-disable
+ import/prefer-default-export */
+export const sendVoteResult = ({ cardID, DuckStamp, event }) => {
+  if (CardManager.votedCard === cardID) {
+    CardManager.voteCard(null);
+    DuckStamp.addClass('hide');
+  } else {
+    const { x, y } = calcPosition(event);
+    CardManager.voteCard(cardID);
+    DuckStamp.removeClass('hide');
+    DuckStamp.move(x, y, 0);
+  }
+  socket.emit('vote card', { cardID: CardManager.votedCard });
+};

--- a/src/frontend/scenes/vote/index.js
+++ b/src/frontend/scenes/vote/index.js
@@ -1,4 +1,3 @@
-import './vote.scss';
 import renderVote from './render';
 
 const Vote = class {

--- a/src/frontend/scenes/vote/index.js
+++ b/src/frontend/scenes/vote/index.js
@@ -1,0 +1,22 @@
+import './vote.scss';
+import renderVote from './render';
+
+const Vote = class {
+  constructor({ endTime }) {
+    this.endTime = endTime;
+  }
+
+  render() {
+    const { endTime } = this;
+    const { arrayToBeRemoved = [] } = renderVote({ endTime });
+    this.arrayToBeRemoved = arrayToBeRemoved;
+  }
+
+  wrapup() {
+    this.arrayToBeRemoved.forEach((gameObject) => {
+      gameObject.delete();
+    });
+  }
+};
+
+export default Vote;

--- a/src/frontend/scenes/vote/render.js
+++ b/src/frontend/scenes/vote/render.js
@@ -1,0 +1,46 @@
+import './vote.scss';
+import TextObject from '@engine/TextObject';
+import SceneManager from '@utils/SceneManager';
+import CardManager from '@utils/CardManager';
+import TEXT from '@utils/text';
+import DuckObject from '@engine/DuckObject';
+import PlayerManager from '@utils/PlayerManager';
+import { sendVoteResult } from './events';
+
+const renderDiscussion = ({ endTime }) => {
+  const { ProgressBar } = SceneManager.sharedComponents;
+  const cards = CardManager.submittedCards;
+
+  const { color } = PlayerManager.getCurrentPlayer();
+  const DuckStamp = new DuckObject({ width: 30, color });
+  DuckStamp.render();
+  DuckStamp.instance.style.borderColor = color;
+  DuckStamp.setOriginCenter();
+  DuckStamp.addClass(['hide', 'movable', 'duck-stamp']);
+  DuckStamp.attachToRoot();
+
+  if (!PlayerManager.isTeller()) {
+    cards.forEach((card) => {
+      card.addClass(['card-glow-gold-hover', 'hover-larger']);
+      card.addClickHandler((event) =>
+        sendVoteResult({ cardID: card.cardID, DuckStamp, event }),
+      );
+    });
+  }
+
+  ProgressBar.setTime(endTime);
+  ProgressBar.start();
+
+  const HelpText = new TextObject();
+  HelpText.addClass('helper-text');
+  HelpText.setContent(TEXT.VOTE.TITLE);
+  HelpText.attachToRoot();
+
+  const arrayToBeRemoved = [DuckStamp];
+
+  return {
+    arrayToBeRemoved,
+  };
+};
+
+export default renderDiscussion;

--- a/src/frontend/scenes/vote/vote.scss
+++ b/src/frontend/scenes/vote/vote.scss
@@ -1,0 +1,6 @@
+.duck-stamp {
+  padding: 5px;
+  border: 2px solid #a00;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 100%;
+}

--- a/src/frontend/scenes/voteResult/index.js
+++ b/src/frontend/scenes/voteResult/index.js
@@ -1,0 +1,16 @@
+import renderVoteResult from './render';
+
+const VoteResult = class {
+  render() {
+    const { arrayToBeRemoved = [] } = renderVoteResult();
+    this.arrayToBeRemoved = arrayToBeRemoved;
+  }
+
+  wrapup() {
+    this.arrayToBeRemoved.forEach((gameObject) => {
+      gameObject.delete();
+    });
+  }
+};
+
+export default VoteResult;

--- a/src/frontend/scenes/voteResult/render.js
+++ b/src/frontend/scenes/voteResult/render.js
@@ -1,0 +1,86 @@
+import './voteResult.scss';
+import TextObject from '@engine/TextObject';
+import CardManager from '@utils/CardManager';
+import TEXT from '@utils/text';
+import DuckObject from '@engine/DuckObject';
+import PlayerManager from '@utils/PlayerManager';
+import GameObject from '@engine/GameObject';
+
+const DIFF_Y_POSITION_STAMP = 14;
+const DIFF_Y_POSITION_NAME = -15;
+const ORIGIN_STAMP = [50, 0];
+const ORIGIN_NAME = [50, 0];
+const WIDTH_STAMP_DUCK = 40;
+const WIDTH_NAME_DUCK = 25;
+
+const renderVoteResult = () => {
+  const cards = CardManager.submittedCards;
+  const players = PlayerManager.getPlayers();
+
+  const containers = cards.reduce((prev, card) => {
+    const { position, cardID } = card;
+    const [cardX, cardY] = position;
+    const stampContainer = new GameObject({
+      position: [cardX, cardY + DIFF_Y_POSITION_STAMP],
+      origin: ORIGIN_STAMP,
+    });
+    stampContainer.addClass('stamp-wrapper');
+    stampContainer.attachToRoot();
+
+    const nameContainer = new GameObject({
+      position: [cardX, cardY - DIFF_Y_POSITION_NAME],
+      origin: ORIGIN_NAME,
+    });
+    nameContainer.addClass('name-wrapper');
+    nameContainer.attachToRoot();
+
+    return {
+      ...prev,
+      [cardID]: {
+        stampContainer,
+        nameContainer,
+      },
+    };
+  }, {});
+
+  const voteResultObjects = players.reduce((prev, player) => {
+    const { color, votedCardID, submittedCardID, nickname, isTeller } = player;
+
+    const { nameContainer } = containers[submittedCardID];
+    const nameDuck = new DuckObject({ color, width: WIDTH_NAME_DUCK });
+    const nicknameText = new TextObject();
+    nameDuck.addClass('duck-stamp');
+    nameDuck.attachToObject(nameContainer);
+    nicknameText.setContent(nickname);
+    nicknameText.addClass('nickname-text');
+    nicknameText.attachToObject(nameContainer);
+
+    if (isTeller) {
+      const tellerCard = cards.find((card) => card.cardID === submittedCardID);
+      tellerCard.addClass('card-glow-gold');
+      return [...prev, nameDuck, nicknameText, nameContainer];
+    }
+
+    const { stampContainer } = containers[votedCardID];
+    const stampDuck = new DuckObject({ color, width: WIDTH_STAMP_DUCK });
+    stampDuck.addClass('duck-stamp');
+    stampDuck.attachToObject(stampContainer);
+    return [...prev, nameDuck, stampDuck, nicknameText, nameContainer];
+  }, []);
+
+  const HelpText = new TextObject();
+  HelpText.addClass(['helper-text', 'vote-result-text']);
+  HelpText.setContent(TEXT.VOTE_RESULT.TITLE);
+  HelpText.attachToRoot();
+
+  const stampContainers = Object.values(containers).map(
+    (container) => container.stampContainer,
+  );
+  const arrayToBeRemoved = [HelpText, ...voteResultObjects, ...stampContainers];
+
+  return {
+    arrayToBeRemoved,
+  };
+};
+
+export default renderVoteResult;

--- a/src/frontend/scenes/voteResult/voteResult.scss
+++ b/src/frontend/scenes/voteResult/voteResult.scss
@@ -1,0 +1,34 @@
+$z-index-mini-duck: 15;
+
+.stamp-wrapper {
+  position: absolute;
+  z-index: $z-index-mini-duck;
+  display: inline-flex;
+  max-width: 150px;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+
+.name-wrapper {
+  position: absolute;
+  z-index: $z-index-mini-duck;
+  display: flex;
+  width: 190px;
+  align-items: center;
+  justify-content: center;
+}
+
+.duck-stamp {
+  box-sizing: border-box;
+  padding: 3px;
+  border-radius: 100%;
+}
+
+.nickname-text {
+  padding: 3px;
+  font-weight: 600;
+}
+
+.vote-result-text {
+  top: 80% !important;
+}

--- a/src/frontend/socket/index.js
+++ b/src/frontend/socket/index.js
@@ -5,6 +5,7 @@ import setupGuesserSelectCard from './guesserSelectCard';
 import setupPlayerWaiting from './playerWaiting';
 import setupMixCard from './mixCard';
 import setupDiscussion from './discussion';
+import setupVote from './vote';
 
 const SocketManager = {
   initializeSocketOn() {
@@ -15,6 +16,7 @@ const SocketManager = {
     setupPlayerWaiting();
     setupMixCard();
     setupDiscussion();
+    setupVote();
   },
 };
 

--- a/src/frontend/socket/index.js
+++ b/src/frontend/socket/index.js
@@ -6,6 +6,7 @@ import setupPlayerWaiting from './playerWaiting';
 import setupMixCard from './mixCard';
 import setupDiscussion from './discussion';
 import setupVote from './vote';
+import setupVoteResult from './voteResult';
 
 const SocketManager = {
   initializeSocketOn() {
@@ -17,6 +18,7 @@ const SocketManager = {
     setupMixCard();
     setupDiscussion();
     setupVote();
+    setupVoteResult();
   },
 };
 

--- a/src/frontend/socket/vote.js
+++ b/src/frontend/socket/vote.js
@@ -1,0 +1,5 @@
+import socket from '@utils/socket';
+
+const setupVote = () => {};
+
+export default setupVote;

--- a/src/frontend/socket/vote.js
+++ b/src/frontend/socket/vote.js
@@ -1,5 +1,20 @@
 import socket from '@utils/socket';
+import SceneManager from '@utils/SceneManager';
+import VoteResult from '@scenes/voteResult';
+import PlayerManager from '../utils/PlayerManager';
 
-const setupVote = () => {};
+const setupVote = () => {
+  const onEndVote = ({ players }) => {
+    players.forEach((playerInfo) => {
+      const { socketID } = playerInfo;
+      const player = PlayerManager.get(socketID);
+      player.updateScore(playerInfo);
+      player.updateCard(playerInfo);
+    });
+    SceneManager.renderNextScene(new VoteResult());
+  };
+
+  socket.on('end vote', onEndVote);
+};
 
 export default setupVote;

--- a/src/frontend/socket/voteResult.js
+++ b/src/frontend/socket/voteResult.js
@@ -1,0 +1,9 @@
+import socket from '@utils/socket';
+
+const setupVoteResult = () => {
+  const onEndVoteResult = () => {};
+
+  socket.on('end vote result', onEndVoteResult);
+};
+
+export default setupVoteResult;

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -11,6 +11,7 @@ const CardManager = class {
     this.submittedCards = [];
     this.beforeSubmittedCount = 0;
     this.votedCard = null;
+    // selectedCard와 votedCard는 Player로 옮김. 지울 예정
   }
 
   initailizeMyCards(cards) {

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -10,6 +10,7 @@ const CardManager = class {
     this.topic = null;
     this.submittedCards = [];
     this.beforeSubmittedCount = 0;
+    this.votedCard = null;
   }
 
   initailizeMyCards(cards) {
@@ -22,6 +23,10 @@ const CardManager = class {
 
   selectCard(selectedCard) {
     this.selectedCard = selectedCard;
+  }
+
+  voteCard(votedCard) {
+    this.votedCard = votedCard;
   }
 
   removeSelectedCard() {

--- a/src/frontend/utils/Player.js
+++ b/src/frontend/utils/Player.js
@@ -5,7 +5,6 @@ const Player = class {
     socketID,
     nickname,
     color,
-    score = 0,
     isTeller = false,
     isCurrentPlayer = false,
     isReady = false,
@@ -13,11 +12,17 @@ const Player = class {
     this.socketID = socketID;
     this.nickname = nickname;
     this.color = color;
-    this.score = score;
+    this.score = {
+      correct: 0,
+      bonus: 0,
+      total: 0,
+    };
     this.isTeller = isTeller;
     this.isCurrentPlayer = isCurrentPlayer;
     this.isReady = isReady;
     this.duck = new DuckCursorObject({ isReady, color });
+    this.votedCardID = null;
+    this.submittedCardID = null;
   }
 
   update(params) {
@@ -37,6 +42,22 @@ const Player = class {
     if (this.isReady === value) return;
     this.isReady = value;
     this.duck.setVisibility(value, this.isCurrentPlayer);
+  }
+
+  updateScore(score) {
+    const { correctScore: correct, bonusScore: bonus, totalScore } = score;
+    const total = this.score.total + totalScore;
+    this.score = {
+      correct,
+      bonus,
+      total,
+    };
+  }
+
+  updateCard(cards) {
+    const { votedCardID, submittedCardID } = cards;
+    this.submittedCardID = submittedCardID;
+    this.votedCardID = votedCardID;
   }
 };
 

--- a/src/frontend/utils/PlayerManager.js
+++ b/src/frontend/utils/PlayerManager.js
@@ -89,14 +89,6 @@ const PlayerManager = class extends Map {
   isTeller() {
     return this.currentPlayerID === this.tellerID;
   }
-
-  getPlayerBySubmittedCard(cardID) {
-    return [...this.map].find((player) => player.sumbittedCardID === cardID);
-  }
-
-  getPlayersByVotedCard(cardID) {
-    return [...this.map].filter((player) => player.votedCardID === cardID);
-  }
 };
 
 export default new PlayerManager();

--- a/src/frontend/utils/PlayerManager.js
+++ b/src/frontend/utils/PlayerManager.js
@@ -89,6 +89,14 @@ const PlayerManager = class extends Map {
   isTeller() {
     return this.currentPlayerID === this.tellerID;
   }
+
+  getPlayerBySubmittedCard(cardID) {
+    return [...this.map].find((player) => player.sumbittedCardID === cardID);
+  }
+
+  getPlayersByVotedCard(cardID) {
+    return [...this.map].filter((player) => player.votedCardID === cardID);
+  }
 };
 
 export default new PlayerManager();

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -1,6 +1,5 @@
 import TextObject from '@engine/TextObject';
 import ProgressBarObject from '@engine/ProgressBarObject';
-import GuesserSelectCard from '@scenes/guesserSelectCard';
 import { $id } from '@utils/dom';
 import PlayerManager from '@utils/PlayerManager';
 import TIME from '@type/time';

--- a/src/frontend/utils/calculate.js
+++ b/src/frontend/utils/calculate.js
@@ -1,0 +1,10 @@
+import { ROOT } from './dom';
+
+export const calcAbsolutePosFromRoot = (event) => {
+  const { clientX: cursorX, clientY: cursorY } = event;
+  const { x: rootX, y: rootY, width, height } = ROOT.getBoundingClientRect();
+  const x = ((cursorX - rootX) / width) * 100;
+  const y = ((cursorY - rootY) / height) * 100;
+
+  return { x, y };
+};

--- a/src/frontend/utils/common.scss
+++ b/src/frontend/utils/common.scss
@@ -53,6 +53,18 @@ html {
   box-shadow: 0 0 4em 1em $white-color;
 }
 
+.helper-text {
+  @include helper-text-white-background;
+  position: absolute;
+  z-index: $z-index-layouts;
+  top: 25%;
+  left: 50%;
+  font-size: x-large;
+  text-align: center;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
 @mixin button {
   display: flex;
   flex-direction: row;
@@ -120,6 +132,7 @@ html {
   @include card-glow-hover;
   &:hover {
     box-shadow: $glow-color-gold;
+    cursor: pointer;
   }
 }
 

--- a/src/frontend/utils/text.js
+++ b/src/frontend/utils/text.js
@@ -40,6 +40,9 @@ const TEXT = {
   VOTE: {
     TITLE: '자신이 생각하는 이야기꾼의 카드에 투표해주세요!',
   },
+  VOTE_RESULT: {
+    TITLE: '카드를 선택한 이유에 대해 대화를 나눠보세요',
+  },
 };
 
 export const GET_IMAGE_PATH = (cardID) => {

--- a/src/frontend/utils/text.js
+++ b/src/frontend/utils/text.js
@@ -37,6 +37,9 @@ const TEXT = {
     WARNING: '한 번 Skip을 누르면 취소할 수 없어요! 신중하게 선택하세요!',
     SKIP: '모든 유저가 스킵했으므로 잠시 후 투표로 넘어갑니다.',
   },
+  VOTE: {
+    TITLE: '자신이 생각하는 이야기꾼의 카드에 투표해주세요!',
+  },
 };
 
 export const GET_IMAGE_PATH = (cardID) => {


### PR DESCRIPTION
## 💁 설명

###  [최근 3개 커밋의 변경사항 참고하여 리뷰해주세요!~](https://github.com/boostcamp-2020/Project18-B-Web-Duxit/pull/217/files/9b369c5d636b97102d3997adc15011a9abd051b2..fd58ff51b25999d6cac7d74f87aeb4e977eb9d67)

- Vote가 끝나고 결과를 보여주는 Vote Result 씬 구현 `슬롯머신 효과는 아직 구현 안함! 내일 할 예정`
- 플레이어 정보를 받으면 플레이어 클래스의 score, votedCardID, submittedCardID 추가함
  - 이게 현재 플레이어의 정보가 CardManager에 이미 있는데.. 암튼 내일 리팩토링할 것! 중복 코드 제거
- 플레이어를 순회하면서 각 플레이어가 제출한 카드에는 자신의 네임덕과 닉네임텍스트를 상단에 보여줌.
- 각 플레이어가 투표한 카드에는 자신의 스탬프덕을 아래에 보여줌
- 텔러는 투표를 하지 않으므로 자신이 낸 카드에 효과만 추가함
- 닉네임과 스탬프들을 담는 div는 container로 추가하여 담음 (flex)

![image](https://user-images.githubusercontent.com/43198553/102091584-5ba21c80-3e62-11eb-8ed7-5ede80ba1fa9.png)


## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 플레이어가 선택한 카드 / 제출한 카드에 맞게 오리들이 보인다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

### Vote 씬 브랜치랑 같이 하다보니... [최근 3개 커밋의 변경사항 참고](https://github.com/boostcamp-2020/Project18-B-Web-Duxit/pull/217/files/9b369c5d636b97102d3997adc15011a9abd051b2..fd58ff51b25999d6cac7d74f87aeb4e977eb9d67)