### PR TITLE
핫픽스: 게임 종료될 때 스테이트 ERROR로 바꿈

### DIFF
--- a/src/backend/sockets/exitRoom.ts
+++ b/src/backend/sockets/exitRoom.ts
@@ -16,6 +16,7 @@ function exitRoom() {
   } else {
     // READY 상태일때 나가면 답이 없음
     socket.in(roomID).emit('game terminated', {})
+    game.setState(GAME_STATE.ERROR)
   }
 
   game.removeUser({ socketID: socket.id });

--- a/src/backend/utils/gameState.js
+++ b/src/backend/utils/gameState.js
@@ -8,6 +8,7 @@ const GAME_STATE = {
   RESULT: 6,
   SCORE: 7,
   END: 8,
+  ERROR: 9,
 };
 
 export default GAME_STATE;


### PR DESCRIPTION
setTimeout으로 인해 나중에 실행되는 메소드로 인해 서버가 터져버림

## 💁 설명

게임 종료될 때 스테이트 ERROR로 바꿈
이제 서버 덜 터질겁니다

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 서버 터지는거 막음

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

