### PR TITLE
타이머가 올바르게 작동하지 않는 버그 수정

### DIFF
--- a/src/frontend/engine/ProgressBarObject.js
+++ b/src/frontend/engine/ProgressBarObject.js
@@ -2,8 +2,9 @@ import { $create, $id } from '@utils/dom';
 import TIME from '@type/time';
 import GameObject from './GameObject';
 
-const RED = '#d82e21';
-const YELLOW = '#ffd600';
+const RED_COLOR = '#d82e21';
+const YELLOW_COLOR = '#ffd600';
+const GREEN_COLOR = '#3ed78d';
 
 const ProgressBarObject = class extends GameObject {
   constructor() {
@@ -31,6 +32,7 @@ const ProgressBarObject = class extends GameObject {
     }
     const [progressBar] = this.getProgessBar();
     progressBar.style.width = '100%';
+    progressBar.style.backgroundColor = GREEN_COLOR;
     this.addClass('hide');
   }
 
@@ -62,8 +64,8 @@ const ProgressBarObject = class extends GameObject {
       const remainTime = endTime - new Date().getTime();
       const widthSize = (remainTime / this.time) * 100;
       progressBar.style.width = `${widthSize}%`;
-      if (widthSize < 30) progressBar.style.backgroundColor = RED;
-      else if (widthSize < 60) progressBar.style.backgroundColor = YELLOW;
+      if (widthSize < 30) progressBar.style.backgroundColor = RED_COLOR;
+      else if (widthSize < 60) progressBar.style.backgroundColor = YELLOW_COLOR;
       timeText.innerText = (remainTime / 1000).toFixed(0);
     }, TIME.HALF_SECOND);
 

--- a/src/frontend/engine/ProgressBarObject.js
+++ b/src/frontend/engine/ProgressBarObject.js
@@ -6,6 +6,12 @@ const RED = '#d82e21';
 const YELLOW = '#ffd600';
 
 const ProgressBarObject = class extends GameObject {
+  constructor() {
+    super();
+    this.timerStack = [];
+    this.timeManagerStack = [];
+  }
+
   setTime(endTime) {
     this.endTime = new Date(endTime).getTime();
     this.time = this.endTime - new Date().getTime();
@@ -15,12 +21,16 @@ const ProgressBarObject = class extends GameObject {
     this.callback = callback;
   }
 
-  finish() {
+  clear() {
     if (this.callback) this.callback();
-    clearInterval(this.progressBarTimer);
-    clearTimeout(this.timeOutlManager);
-    this.progressBarTimer = null;
-    this.timeOutlManager = null;
+    while (this.timerStack.length > 0) {
+      const timer = this.timerStack.pop();
+      const timeManager = this.timeManagerStack.pop();
+      clearInterval(timer);
+      clearTimeout(timeManager);
+    }
+    const [progressBar] = this.getProgessBar();
+    progressBar.style.width = '100%';
     this.addClass('hide');
   }
 
@@ -48,7 +58,7 @@ const ProgressBarObject = class extends GameObject {
     this.removeClass('hide');
     const [progressBar, timeText] = this.getProgessBar();
     const { endTime } = this;
-    this.progressBarTimer = setInterval(() => {
+    const timer = setInterval(() => {
       const remainTime = endTime - new Date().getTime();
       const widthSize = (remainTime / this.time) * 100;
       progressBar.style.width = `${widthSize}%`;
@@ -57,13 +67,12 @@ const ProgressBarObject = class extends GameObject {
       timeText.innerText = (remainTime / 1000).toFixed(0);
     }, TIME.HALF_SECOND);
 
-    this.timeOutManager = setTimeout(() => {
-      this.finish();
+    const timeManager = setTimeout(() => {
+      this.clear();
     }, this.time);
-  }
 
-  clear() {
-    if (this.progressBarTimer) this.finish();
+    this.timerStack.push(timer);
+    this.timeManagerStack.push(timeManager);
   }
 
   remove() {

--- a/src/frontend/game/game.scss
+++ b/src/frontend/game/game.scss
@@ -210,7 +210,7 @@
 .topic-text {
   @include button;
   @include absolute-center-x;
-  top: 16%;
+  top: 15%;
   width: 40%;
   background-color: $main-color;
   font-size: 1.5rem;

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -40,11 +40,8 @@ const SceneManager = {
     let wrapupInterval = TIME.NONE_INTERVAL;
     this.hideAllDucks();
 
-    if (ProgressBar.progressBarTimer && !this.currentScene.passingTimerClear) {
-      ProgressBar.clear();
-    }
-
     if (this.currentScene) {
+      if (!this.currentScene.passingTimerClear) ProgressBar.clear();
       this.currentScene.wrapup();
       wrapupInterval = this.currentScene.wrapupInterval || TIME.NONE_INTERVAL;
     }


### PR DESCRIPTION
## 💁 설명

기존에는 멤버변수로 관리했는데 이게 덮어씌워지면서 문제가 생긴듯합니다.
배열로 관리해서 씬을 접을 때 타이머 배열을 비워줍니다.??
일단 잘 됩니다.

글고 부자연스럽게 다시 채워지는 게 좀 이상해서 끝나면 그냥 100%로 다시 초기화합니다.

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] Progress bar 정상 작동

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 주의 사항 1
- 주의 사항 2
