### PR TITLE
feat: end game scene 버튼 이벤트 지정

### DIFF
--- a/src/frontend/scenes/endGame/events.js
+++ b/src/frontend/scenes/endGame/events.js
@@ -1,0 +1,10 @@
+import SceneManager from '@utils/SceneManager';
+import WaitingRoom from '@scenes/waitingRoom';
+
+export const redirectToLobby = () => {
+  window.location.href = '/';
+};
+
+export const renderWaitingScene = () => {
+  SceneManager.renderNextScene(new WaitingRoom());
+};

--- a/src/frontend/scenes/endGame/render.js
+++ b/src/frontend/scenes/endGame/render.js
@@ -2,6 +2,7 @@ import './style.scss';
 import GameObject from '@engine/GameObject';
 import TextObject from '@engine/TextObject';
 import template from './template.html';
+import { redirectToLobby, renderWaitingScene } from './events';
 
 const renderPlayerGrid = (rowDucks, rowNicknames, rowScores, winnerID) => (
   player,
@@ -47,6 +48,8 @@ const renderScoreboardLayout = ({ players, winnerID } = {}) => {
   players.forEach(
     renderPlayerGrid(rowDucks, rowNicknames, rowScores, winnerID),
   );
+  buttonGoMain.addEventListener(redirectToLobby);
+  buttonRestart.addEventListener(renderWaitingScene);
 
   const arrayToBeRemoved = [Background];
   return {


### PR DESCRIPTION
end game scene에서 메인으로/다시하기 의 이벤트 정의.

#238 이슈 내용 처리하면서 scoreboard에서 다른 scene 넘어갈때 round 초기화 코드가 삽입될텐데, 이거 되는 모습에 따라서 코드 수정이 필요할 수 있습니다.
일단은 그전까지 Draft로 둘 예정이요~
