### PR TITLE
Player ~ Discussion 오리 보이게 하기! + 이전에 낸 오리들 다같이!

### DIFF
--- a/src/frontend/scenes/discussion/index.js
+++ b/src/frontend/scenes/discussion/index.js
@@ -3,6 +3,7 @@ import renderDiscussion from './render';
 const Discussion = class {
   constructor({ endTime }) {
     this.endTime = endTime;
+    this.bMaintainDucks = true;
   }
 
   render() {

--- a/src/frontend/scenes/mixCard/index.js
+++ b/src/frontend/scenes/mixCard/index.js
@@ -3,6 +3,7 @@ import renderMixCard from './render';
 const MixCard = class {
   constructor(endTime) {
     this.endTime = endTime;
+    this.bMaintainDucks = true;
   }
 
   render() {

--- a/src/frontend/scenes/playerWaiting/index.js
+++ b/src/frontend/scenes/playerWaiting/index.js
@@ -1,4 +1,5 @@
 import CardManager from '@utils/CardManager';
+import SceneManager from '@utils/SceneManager';
 import renderPlayerWaiting from './render';
 
 const PlayerWaiting = class {
@@ -6,7 +7,7 @@ const PlayerWaiting = class {
     this.endTime = endTime || null;
     this.ducks = new Map();
 
-    Array.from({ length: CardManager.beforeSubmittedCount }, () =>
+    SceneManager.beforeSubmittingPlayers.forEach(() =>
       CardManager.dropNewCard(),
     );
   }

--- a/src/frontend/scenes/playerWaiting/render.js
+++ b/src/frontend/scenes/playerWaiting/render.js
@@ -6,8 +6,13 @@ import TEXT from '@utils/text';
 
 const renderPlayerWaiting = ({ endTime }) => {
   const isTeller = PlayerManager.isTeller();
-  const tellerDuck = PlayerManager.getTeller().duck;
-  tellerDuck.setVisibility(true, isTeller);
+  const currentPlayer = PlayerManager.getCurrentPlayer();
+
+  SceneManager.beforeSubmittingPlayers.forEach((playerID) => {
+    const bMyDuck = playerID === currentPlayer.socketID;
+    const { duck } = PlayerManager.get(playerID);
+    duck.setVisibility(true, bMyDuck);
+  });
 
   if (isTeller) {
     const { ProgressBar } = SceneManager.sharedComponents;

--- a/src/frontend/socket/guesserSelectCard.js
+++ b/src/frontend/socket/guesserSelectCard.js
@@ -8,17 +8,15 @@ import GuesserSelectCard from '@scenes/guesserSelectCard';
 const setupGuesserSelectCard = () => {
   const onGuesserSelectCard = ({ cardID }) => {
     if (!SceneManager.isCurrentScene(GuesserSelectCard)) return;
-    CardManager.addSubmittedCardCount();
+    const currentPlayer = PlayerManager.getCurrentPlayer();
     CardManager.selectCard(cardID);
+    SceneManager.addBeforeSubmittingPlayers(currentPlayer.socketID);
     SceneManager.renderNextScene(new PlayerWaiting());
-
-    const myDuck = PlayerManager.getCurrentPlayer().duck;
-    myDuck.setVisibility(true, true);
   };
 
-  const onOtherGuesserSelectCard = () => {
+  const onOtherGuesserSelectCard = ({ playerID }) => {
     if (!SceneManager.isCurrentScene(GuesserSelectCard)) return;
-    CardManager.addSubmittedCardCount();
+    CardManager.addBeforeSubmittingPlayers(playerID);
   };
 
   socket.on('guesser select card', onGuesserSelectCard);

--- a/src/frontend/socket/guesserWaiting.js
+++ b/src/frontend/socket/guesserWaiting.js
@@ -3,12 +3,13 @@ import SceneManager from '@utils/SceneManager';
 import CardManager from '@utils/CardManager';
 import GuesserSelectCard from '@scenes/guesserSelectCard';
 import GuesserWaiting from '@scenes/guesserWaiting';
+import PlayerManager from '@utils/PlayerManager';
 
 const setupGuesserWaiting = () => {
   const onTellerSelectCard = ({ topic, endTime }) => {
     if (!SceneManager.isCurrentScene(GuesserWaiting)) return;
     CardManager.updateTopic(topic);
-    CardManager.addSubmittedCardCount();
+    SceneManager.addBeforeSubmittingPlayers(PlayerManager.tellerID);
     SceneManager.renderNextScene(new GuesserSelectCard({ endTime }));
   };
 

--- a/src/frontend/socket/scoreboard.js
+++ b/src/frontend/socket/scoreboard.js
@@ -16,6 +16,7 @@ const onTellerSelect = ({ tellerID, cards, endTime }) => {
   if (!SceneManager.isCurrentScene(Scoreboard)) return;
   PlayerManager.setTellerID(tellerID);
   CardManager.initializeMyCards(cards);
+  SceneManager.initializeSubmiitingPlayers();
   const { isTeller } = PlayerManager.getCurrentPlayer();
   const nextScene = isTeller
     ? new TellerSelectCard({ cards, endTime })

--- a/src/frontend/socket/tellerSelectCard.js
+++ b/src/frontend/socket/tellerSelectCard.js
@@ -3,13 +3,14 @@ import SceneManager from '@utils/SceneManager';
 import CardManager from '@utils/CardManager';
 import PlayerWaiting from '@scenes/playerWaiting';
 import TellerSelectCard from '@scenes/tellerSelectCard';
+import PlayerManager from '@utils/PlayerManager';
 
 const setupTellerSelectSocket = () => {
   const onTellerSelectCard = ({ cardID, topic, endTime }) => {
     if (!SceneManager.isCurrentScene(TellerSelectCard)) return;
     CardManager.updateTopic(topic);
-    CardManager.addSubmittedCardCount();
     CardManager.selectCard(cardID);
+    SceneManager.addBeforeSubmittingPlayers(PlayerManager.tellerID);
     SceneManager.renderNextScene(new PlayerWaiting(endTime));
   };
 

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -9,7 +9,7 @@ const CardManager = class {
     this.selectedCard = null;
     this.topic = null;
     this.submittedCards = [];
-    this.beforeSubmittedCount = 0;
+    this.beforeSubmittingPlayers = [];
     this.votedCard = null;
     // selectedCard와 votedCard는 Player로 옮김. 지울 예정
   }
@@ -17,7 +17,7 @@ const CardManager = class {
   initializeMyCards(cards) {
     this.myCards = cards;
     this.submittedCards = [];
-    this.beforeSubmittedCount = 0;
+    this.beforeSubmittingPlayers = [];
     this.selectedCard = null;
     this.votedCard = null;
     this.topic = null;
@@ -43,8 +43,8 @@ const CardManager = class {
     this.topic = topic;
   }
 
-  addSubmittedCardCount() {
-    this.beforeSubmittedCount += 1;
+  addBeforeSubmittingPlayers(playerID) {
+    this.beforeSubmittingPlayers = [...this.beforeSubmittingPlayers, playerID];
   }
 
   addSubmittedCard(cardObject) {

--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -9,7 +9,6 @@ const CardManager = class {
     this.selectedCard = null;
     this.topic = null;
     this.submittedCards = [];
-    this.beforeSubmittingPlayers = [];
     this.votedCard = null;
     // selectedCard와 votedCard는 Player로 옮김. 지울 예정
   }
@@ -17,7 +16,6 @@ const CardManager = class {
   initializeMyCards(cards) {
     this.myCards = cards;
     this.submittedCards = [];
-    this.beforeSubmittingPlayers = [];
     this.selectedCard = null;
     this.votedCard = null;
     this.topic = null;
@@ -41,10 +39,6 @@ const CardManager = class {
 
   updateTopic(topic) {
     this.topic = topic;
-  }
-
-  addBeforeSubmittingPlayers(playerID) {
-    this.beforeSubmittingPlayers = [...this.beforeSubmittingPlayers, playerID];
   }
 
   addSubmittedCard(cardObject) {

--- a/src/frontend/utils/SceneManager.js
+++ b/src/frontend/utils/SceneManager.js
@@ -11,6 +11,7 @@ const root = $id('root');
 const SceneManager = {
   currentScene: null,
   sharedComponents: [],
+  beforeSubmittingPlayers: [],
 
   initializeComponents() {
     const AllReadyText = new TextObject();
@@ -38,13 +39,14 @@ const SceneManager = {
   renderNextScene(scene, ...args) {
     const { ProgressBar } = this.sharedComponents;
     let wrapupInterval = TIME.NONE_INTERVAL;
-    this.hideAllDucks();
 
     if (this.currentScene) {
       if (!this.currentScene.passingTimerClear) ProgressBar.clear();
       this.currentScene.wrapup();
       wrapupInterval = this.currentScene.wrapupInterval || TIME.NONE_INTERVAL;
     }
+    if (!scene.bMaintainDucks) this.hideAllDucks();
+
     setTimeout(() => {
       scene.render(root, args);
       this.currentScene = scene;
@@ -60,6 +62,14 @@ const SceneManager = {
     players.forEach((player) =>
       player.duck.setVisibility(false, player.isCurrentPlayer),
     );
+  },
+
+  addBeforeSubmittingPlayers(playerID) {
+    this.beforeSubmittingPlayers = [...this.beforeSubmittingPlayers, playerID];
+  },
+
+  initializeSubmiitingPlayers() {
+    this.beforeSubmittingPlayers = [];
   },
 };
 


### PR DESCRIPTION
## 💁 설명

### 문제
- 이전에 냈던 플레이어의 오리가 보이지 않는 문제가 있었음
- 씬 매니저에서 플레이어의 아이디를 저장하여 player waiting 렌더링할 때 순회하면서 렌더함

플레이어 웨이팅 ~ Discussion 에서는 오리가 계속 보인다 ㅇㅅㅇ

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] Player ~ Discussion 오리가 보인다
- [ ] 이전에 냈던 플레이어의 오리도 보인다.

## 🚧 주의 사항

> PR을 읽을 때 살펴볼 사항

- 주의 사항 1
- 주의 사항 2
