### PR TITLE
fix: 카드가 안 받아졌어도 나중에 다시 받게 함

### DIFF
--- a/src/frontend/utils/CardManager.js
+++ b/src/frontend/utils/CardManager.js
@@ -46,6 +46,21 @@ const CardManager = class {
   }
 
   updateCardInformation(cardIDs) {
+    const cardQuantityDifference = cardIDs.length - this.submittedCards.length;
+
+    if (cardQuantityDifference > 0) {
+      Array.from({ length: cardQuantityDifference }).forEach(() =>
+        this.dropNewCard(),
+      );
+    }
+
+    if (cardQuantityDifference < 0) {
+      this.submittedCards
+        .slice(0, -cardQuantityDifference)
+        .forEach((card) => card.delete());
+      this.submittedCards = this.submittedCards.slice(-cardQuantityDifference);
+    }
+
     this.submittedCards.forEach((card, idx) =>
       card.setCardInformation(cardIDs[idx]),
     );


### PR DESCRIPTION
## 💁 설명

other guesser decision이 여러 씬에서 정의 되어있기 때문에 씬이 바뀌는 중간에 들어오면
카드를 더 받거나 카드를 덜 받을 수 있음

하지만 결국 get all decisions에서 정확한 카드 수가 전달되므로 여기서 카드 수를 수정하게 함

테스트 했지만 카드가 많이 왔을 경우는 재현이 불가능했음. 하지만 일단 코드를 작성 해 둠

## 📑 체크리스트

> 구현한 목록 체크리스트

- [ ] 카드가 적게 왔을 경우
- [ ] 카드가 많이 왔을 경우(?)

## 🚧 주의 사항


